### PR TITLE
docs: Add USB camera troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ The Joshua Control Panel (Qt6 C++ GUI) ties it together: you can create or load 
   sudo usermod -aG dialout $USER # Then reboot
   ```
 
+- **Camera Access:**  
+  For USB cameras (especially HHWei cameras), ensure proper video device access:
+  ```bash
+  sudo usermod -aG video $USER
+  newgrp video
+  ```
+
 ### Example: Running SO100 Teleoperation with Follower and Lead Arm
 
 This example demonstrates how to launch the SO100 robot in teleoperation mode, with both the follower and lead arm managed according to your configuration file. The configuration file is predefined at [`config/config_preset/so100_teleoperate.pbtxt`](config/config_preset/so100_teleoperate.pbtxt).
@@ -60,6 +67,38 @@ bazel build node_generator:joshua_main
 ```
 
 TODO: Add calibration instruction here.
+
+## Troubleshooting
+
+### USB Camera Not Detected
+
+If your USB camera (especially HHWei cameras) is not showing up as `/dev/video*` devices:
+
+1. **Check if camera is detected by USB:**
+   ```bash
+   lsusb | grep -i camera
+   ```
+
+2. **Ensure you're in the video group:**
+   ```bash
+   sudo usermod -aG video $USER
+   newgrp video
+   ```
+
+3. **Check if UVC drivers are loaded:**
+   ```bash
+   lsmod | grep uvc
+   ```
+
+4. **If no video devices appear, try unplugging and reconnecting the camera** - this often resolves initialization issues.
+
+5. **Verify camera is working:**
+   ```bash
+   ls -l /dev/video*
+   v4l2-ctl --list-devices
+   ```
+
+**Solution Summary:** The most common fix is adding your user to the `video` group and unplugging/reconnecting the camera to trigger proper device node creation.
 
 ## Key Features & Benefits:
 


### PR DESCRIPTION
## Overview
This PR adds comprehensive troubleshooting documentation for USB cameras, specifically addressing common issues with HHWei cameras not being detected as video devices.

## Changes Made
- **Prerequisites**: Added camera access permissions section
- **Troubleshooting Guide**: Added step-by-step diagnostic and solution process
- **Specific Solution**: Documented the unplug/reconnect fix for video device creation
- **Commands**: Included all necessary diagnostic commands (lsusb, lsmod, v4l2-ctl, etc.)

## Problem Solved
HHWei USB cameras (and similar devices) are often detected by USB but don't create `/dev/video*` device nodes on initial connection. This documentation provides users with:
1. Proper permission setup (video group)
2. Diagnostic steps to identify the issue
3. The most effective solution (unplug/reconnect)
4. Verification commands to confirm the fix

## Testing
- Tested with HHWei USB Camera (ID: 1c45:6200)
- Confirmed solution works for creating `/dev/video0` and `/dev/video1` devices
- Verified camera supports up to 1920x1080 at 30fps

## Impact
- Improves user experience for camera setup
- Reduces support requests for common camera detection issues
- Provides clear, actionable troubleshooting steps