### PR TITLE
docs: Add serial device troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,58 @@ bazel build node_generator:joshua_main
 
 TODO: Add calibration instruction here.
 
+## Troubleshooting
+
+### Serial Device Permission Issues (`/dev/ttyACM0`)
+
+If you encounter permission errors when accessing serial devices like `/dev/ttyACM0`, follow these diagnostic steps:
+
+#### 1. Check Device Existence and Permissions
+```bash
+ls -la /dev/ttyACM*
+```
+**Expected output**: `crw-rw---- 1 root dialout 166, 0 /dev/ttyACM0`
+
+#### 2. Verify Your User Groups
+```bash
+groups $USER
+```
+**Check if**: `dialout` group is listed in your groups
+
+#### 3. Test Device Access
+```bash
+timeout 2 cat /dev/ttyACM0 2>&1 || echo "Cannot read from device"
+```
+
+#### 4. Diagnose the Issue
+- **If device doesn't exist**: Check hardware connection and power
+- **If permission denied**: You need `dialout` group membership
+- **If device exists but no permission**: Add yourself to dialout group
+
+#### 5. Fix Permission Issues
+```bash
+# Add your user to the dialout group
+sudo usermod -a -G dialout $USER
+
+# Restart your session (log out/in or restart terminal)
+# Then test access again
+timeout 2 cat /dev/ttyACM0
+```
+
+#### 6. Verify Hardware Connection
+```bash
+# Check USB devices
+lsusb
+
+# Check device information
+sudo udevadm info --name=/dev/ttyACM0
+```
+
+**Common Issues:**
+- **Permission denied**: User not in `dialout` group
+- **Device not found**: Hardware not connected or powered
+- **Access after group change**: Need to restart session for group membership to take effect
+
 ## Key Features & Benefits:
 
 ### Simplified Configuration

--- a/README.md
+++ b/README.md
@@ -55,15 +55,15 @@ TODO: Add calibration instruction here.
 
 ## Troubleshooting
 
-### Serial Device Permission Issues (`/dev/ttyACM0`)
-
-If you encounter permission errors when accessing serial devices like `/dev/ttyACM0`, follow these diagnostic steps:
+### If your robot is not moving, check Serial Device Permission Issues (`/dev/ttyACM0`)
 
 #### 1. Check Device Existence and Permissions
 ```bash
 ls -la /dev/ttyACM*
 ```
 **Expected output**: `crw-rw---- 1 root dialout 166, 0 /dev/ttyACM0`
+
+If you encounter permission errors when accessing serial devices like `/dev/ttyACM0`, follow these diagnostic steps:
 
 #### 2. Verify Your User Groups
 ```bash


### PR DESCRIPTION
## Overview
This PR adds comprehensive troubleshooting documentation for serial device permission issues, specifically for  access problems.

## Changes
- Added detailed troubleshooting section to README.md
- Included step-by-step diagnostic commands
- Documented common permission issues and solutions
- Provided hardware connection verification steps

## Problem Solved
Users encountering permission denied errors when accessing serial devices like  can now follow a systematic approach to diagnose and resolve the issue.

## Testing
- Documentation includes exact commands that were used to diagnose and fix the permission issue
- All diagnostic steps have been verified to work correctly

## Related Issue
Resolves serial device permission issues that prevent users from accessing servo hardware through USB-serial adapters.