### PR TITLE
PyBricks on top of the python HW abstraction layer

### DIFF
--- a/config/config_preset/python_spike_actuator_example.pbtxt
+++ b/config/config_preset/python_spike_actuator_example.pbtxt
@@ -1,0 +1,77 @@
+general {
+  operation_mode: MODE_INFERENCE
+  robot_type: ROBOT_TYPE_MANIPULATOR_ARM
+  name: "python_spike_actuator_example"
+  id: 901
+}
+
+robot {
+  actions {
+    single_actions {
+      node {
+        id: 901
+        node_type: ACTUATOR_SUBSCRIBER
+        qos_setting { depth: 10 }
+        subscriptions {
+          ros2_data_type: FLOAT32
+          topic: "spike/motor_A/command"
+        }
+      }
+      action_type: ACTUATOR
+      actuator {
+        actuator_name: "spike_motor_A"
+        id: 1
+        actuator_type: SPIKE_MOTOR
+        comm {
+          comm_type: BLE
+        }
+        spike_motor_config {
+          hub_id: "Pybricks Hub"
+          port: "A"
+        }
+        physical_lower_limit: 0
+        physical_upper_limit: 1000
+        operational_lower_limit: 0
+        operational_upper_limit: 1000
+        encoder_data_mode: ENCODER_DATA_MODE_RAW
+      }
+    }
+    single_actions {
+      node {
+        id: 901
+        node_type: ACTUATOR_SUBSCRIBER
+        qos_setting { depth: 10 }
+        subscriptions {
+          ros2_data_type: FLOAT32
+          topic: "spike/motor_B/command"
+        }
+      }
+      action_type: ACTUATOR
+      actuator {
+        actuator_name: "spike_motor_B"
+        id: 2
+        actuator_type: SPIKE_MOTOR
+        comm {
+          comm_type: BLE
+        }
+        spike_motor_config {
+          hub_id: "Pybricks Hub"
+          port: "B"
+        }
+        physical_lower_limit: 0
+        physical_upper_limit: 1000
+        operational_lower_limit: 0
+        operational_upper_limit: 1000
+        encoder_data_mode: ENCODER_DATA_MODE_RAW
+      }
+    }
+  }
+  perceptions {}
+}
+
+ai {
+  models {}
+  data_stores {}
+}
+
+calibration {}

--- a/config/config_preset/python_spike_actuator_example.pbtxt
+++ b/config/config_preset/python_spike_actuator_example.pbtxt
@@ -65,6 +65,35 @@ robot {
         encoder_data_mode: ENCODER_DATA_MODE_RAW
       }
     }
+    single_actions {
+      node {
+        id: 901
+        node_type: ACTUATOR_SUBSCRIBER
+        qos_setting { depth: 10 }
+        subscriptions {
+          ros2_data_type: FLOAT32
+          topic: "spike/motor_C/command"
+        }
+      }
+      action_type: ACTUATOR
+      actuator {
+        actuator_name: "spike_motor_C"
+        id: 3
+        actuator_type: SPIKE_MOTOR
+        comm {
+          comm_type: BLE
+        }
+        spike_motor_config {
+          hub_id: "Pybricks Hub"
+          port: "C"
+        }
+        physical_lower_limit: 0
+        physical_upper_limit: 1000
+        operational_lower_limit: 0
+        operational_upper_limit: 1000
+        encoder_data_mode: ENCODER_DATA_MODE_RAW
+      }
+    }
   }
   perceptions {}
 }

--- a/docs/pybricks_test.md
+++ b/docs/pybricks_test.md
@@ -1,0 +1,120 @@
+# Pybricks Test Guide (Beginner)
+
+This guide walks you through verifying the Pybricks motor control end‑to‑end.
+It assumes you are in the repo root.
+
+## 1) Flash Pybricks firmware
+1. Go to `https://code.pybricks.com/`.
+2. Follow the instructions to flash Pybricks firmware to your Spike hub.
+3. Power‑cycle the hub after flashing.
+
+## 2) Install host dependencies
+Use the system Python used by ROS:
+```bash
+source /opt/ros/humble/setup.bash
+python3 -m pip install "pybricksdev[usb,ble]"
+```
+
+## 3) Find your hub name (BLE)
+Turn on the hub so it advertises, then run:
+```bash
+python3 - <<'PY'
+import asyncio
+from bleak import BleakScanner
+
+async def main():
+    devices = await BleakScanner.discover(timeout=5)
+    for d in devices:
+        if d.name:
+            print(d.address, d.name)
+asyncio.run(main())
+PY
+```
+Use the printed name as your `hub_id` (example: `Pybricks Hub`).
+
+## 4) Quick BLE smoke test (no ROS)
+This uploads a tiny Pybricks program to the hub and sends one angle command.
+```bash
+bazel run //tools/pybricks:pybricks_ble_smoke -- "Pybricks Hub" A 90
+```
+Note: the smoke test tool lives under `tools/pybricks`.
+Expected output includes:
+```
+READY
+OK A 90.0
+```
+Your motor should move to 90 degrees.
+
+## 4.5) Upload the hub helper program (required for Python bridge)
+Run this once to load the helper on the hub:
+```bash
+pybricksdev run ble scripts/pybricks_spike_bridge.py
+```
+Wait for upload to finish, then press Ctrl+C to free the BLE connection.
+
+## 5) Run the ROS actuator subscriber
+In one terminal:
+```bash
+conda deactivate
+source /opt/ros/humble/setup.bash
+bazel run //ros2:actuator_subscriber_py -- actuator_subscriber 901 config/config_preset/python_spike_actuator_example.pbtxt
+```
+You should see:
+```
+READY
+Actuator subscriber node started with 1 actuators for node_id 901!
+```
+
+## 6) Send a single ROS command
+In a second terminal:
+```bash
+conda deactivate
+source /opt/ros/humble/setup.bash
+ros2 topic pub spike/motor_A/command std_msgs/msg/Float32 "{data: 90.0}"
+```
+The motor should move to 90 degrees.
+
+## 7) Continuous motion (sine wave)
+Use the included script for motor A and motor B (run in two terminals):
+
+Motor A:
+```bash
+conda deactivate
+source /opt/ros/humble/setup.bash
+/usr/bin/python3 scripts/spike_wave_publisher.py --topic /spike/motor_A/command
+```
+
+Motor B:
+```bash
+conda deactivate
+source /opt/ros/humble/setup.bash
+/usr/bin/python3 scripts/spike_wave_publisher.py --topic /spike/motor_B/command --offset 60 --amplitude 30
+```
+
+## Troubleshooting
+- If BLE connect fails: power‑cycle the hub and retry.
+- If you see `ModuleNotFoundError: rclpy._rclpy_pybind11`, you’re using conda Python.
+  Use `/usr/bin/python3` after `conda deactivate`.
+- If the motor doesn’t move, double‑check the port (`A/B/C/D`) and hub name.
+
+### BLE connection fail
+Intel Bluetooth adapters (specifically the Intel AX210, AC 9260, and similar chips) are notorious for two specific issues on Linux that would cause your TimeoutError:
+
+Stale GATT Caches: The Intel driver often caches the "services" of a device the first time it sees it. If you saw the Spike Hub before you installed the Pybricks firmware, the Intel driver "remembers" it as a standard LEGO hub. When pybricksdev scans for a "Pybricks" service, the Intel driver says "I know that device; it doesn't have that service," and ignores the hub entirely.
+
+Firmware Lockups: Under heavy scanning (like when 3 Samsung TVs are nearby), the Intel Bluetooth firmware can occasionally enter a state where it reports device addresses but fails to resolve "Advertisement Data" (the metadata like names and UUIDs).
+
+To work around these issues, you can use an external Bluetooth dongle instead of the built-in adapter:
+
+1. Connect an external Bluetooth dongle to your system
+2. Check available Bluetooth interfaces:
+   ```bash
+   hciconfig -a
+   # You will see two interface (e.g. hci0 and hic1)
+   ```
+3. Disable the built-in Bluetooth adapter (typically `hci0`) to force the system to use the dongle:
+   ```bash
+   sudo hciconfig hci0 down
+   ```
+
+This will ensure the system uses only the external dongle for Bluetooth connections.

--- a/docs/spike_python_driver_plan.md
+++ b/docs/spike_python_driver_plan.md
@@ -1,0 +1,85 @@
+# Spike Python Driver Plan
+
+Goal: Support Pybricks motors through the Python robot layer, replacing the separate
+python_bridge process with Python actuator nodes.
+
+## Phases (testable outcomes)
+
+1) Phase 1 - Schema & config (completed)
+2) Phase 2 - Python driver implementation (completed)
+3) Phase 3 - Factory wiring (completed)
+4) Phase 4 - ROS node integration (no hardware) (completed)
+5) Phase 5 - Hardware smoke test (completed)
+
+## Phase 1: Schema & config (focus)
+
+Deliverables
+- Add a Pybricks actuator type and config in `robot/action/proto/action.proto`.
+- Optional: add explicit BLE/USB comm types in `robot/comm/proto/comm.proto`
+  (or reuse `serial_config.port` with values like "A", "B", etc.).
+- Add a small pbtxt example that uses the new actuator type.
+
+Proposed edits
+- `robot/action/proto/action.proto`
+  - `ActuatorType` add `SPIKE_MOTOR = <new_id>`
+  - `oneof action_config` add `SpikeMotorConfig spike_motor_config = <new_id>`
+  - `message SpikeMotorConfig` fields (choose and confirm):
+    - `string hub_id` (optional; for multi-hub BLE selection)
+    - `string port` (e.g., "A", "B", "C", "D")
+    - `bool use_ble` / `bool use_usb` (or use comm fields instead)
+- `robot/comm/proto/comm.proto` (optional)
+  - `CommType` add `BLE = <new_id>`, `USB = <new_id>`
+  - Add `BleConfig` / `UsbConfig` messages if you want structured transport config.
+- Add example pbtxt:
+  - `config/config_preset/python_spike_actuator_example.pbtxt`
+
+Test commands
+1) Build protos:
+   - `bazel build //robot/action/proto:... //robot/comm/proto:... //config/proto:...`
+2) Validate pbtxt parsing:
+   - `bazel run //utils:config_loader -- config/config_preset/python_spike_actuator_example.pbtxt`
+   - If `config_loader` is not available, use your existing config validation command.
+
+Notes
+- Keep transport config minimal for Phase 1; use whichever fields make implementation
+  simpler in Phase 2 (BLE/USB selection can be refined later).
+
+Completed work
+- Added `SPIKE_MOTOR` actuator type and `SpikeMotorConfig` (`hub_id`, `port`).
+- Added `BLE` to `CommType`.
+- Added example config: `config/config_preset/python_spike_actuator_example.pbtxt`.
+
+## Phase 2: Python driver implementation (decisions)
+
+Decisions
+- Control mode: absolute angle commands.
+- Transport: direct Pybricks control (no helper script).
+- Hub selection: `hub_id` only.
+- Commanding: send immediately on each `set_action`.
+
+Implementation notes
+- Implemented a BLE transport that uploads a minimal Pybricks program and sends
+  `SET <PORT> <ANGLE>` commands over stdin.
+
+Completed work
+- Added Pybricks driver: `robot/action/motors/drivers/pybricks_driver.py`.
+- Added BLE transport: `robot/comm/pybricks_ble_transport.py`.
+- Added unit tests: `robot/action/motors/drivers/pybricks_driver_test.py`.
+- Added BLE smoke script: `tools/pybricks/pybricks_ble_smoke.py`.
+
+## Phase 3: Factory wiring
+
+Completed work
+- Wired `SPIKE_MOTOR` into `robot/action/factory/action_factory.py`.
+- Added factory test: `robot/action/factory/action_factory_test.py`.
+
+## Phase 4: ROS node integration (no hardware)
+
+Completed work
+- Verified actuator subscriber logic with existing test flow (skips without rclpy).
+
+## Phase 5: Hardware smoke test
+
+Completed work
+- BLE smoke test moved motor using `pybricks_ble_smoke`.
+- ROS actuator subscriber drove motor A and B via topics.

--- a/robot/action/factory/BUILD
+++ b/robot/action/factory/BUILD
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 cc_library(
     name = "action_factory",
@@ -23,6 +23,18 @@ py_library(
     deps = [
         "//robot/action/interfaces:action_interface_py",
         "//robot/action/motors/drivers:mock_driver_py",
+        "//robot/action/motors/drivers:pybricks_driver_py",
         "//robot/action/proto:action_py_proto",
+    ],
+)
+
+py_test(
+    name = "action_factory_test",
+    srcs = ["action_factory_test.py"],
+    deps = [
+        ":action_factory_py",
+        "//robot/action/motors/drivers:mock_driver_py",
+        "//robot/action/proto:action_py_proto",
+        "//robot/comm/proto:comm_py_proto",
     ],
 )

--- a/robot/action/factory/action_factory.py
+++ b/robot/action/factory/action_factory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from robot.action.interfaces.action_interface import ActionInterface
 from robot.action.motors.drivers.mock_driver import MockDriver
+from robot.action.motors.drivers.pybricks_driver import PybricksMotorDriver
 from robot.action.proto import action_pb2
 
 
@@ -10,6 +11,10 @@ def create_action(single_action: action_pb2.SingleAction) -> ActionInterface:
         actuator = single_action.actuator
         if actuator.actuator_type == action_pb2.ActuatorType.MOCK_MOTOR:
             driver = MockDriver(actuator)
+            driver.init()
+            return driver
+        if actuator.actuator_type == action_pb2.ActuatorType.SPIKE_MOTOR:
+            driver = PybricksMotorDriver(actuator)
             driver.init()
             return driver
         raise ValueError("Invalid actuator type")

--- a/robot/action/factory/action_factory_test.py
+++ b/robot/action/factory/action_factory_test.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest import mock
+
+from robot.action.factory import action_factory
+from robot.action.motors.drivers.mock_driver import MockDriver
+from robot.action.proto import action_pb2
+from robot.comm.proto import comm_pb2
+
+
+class ActionFactoryTest(unittest.TestCase):
+    def _make_single_action(self, actuator_type: int):
+        single = action_pb2.SingleAction()
+        single.action_type = action_pb2.ActionType.ACTUATOR
+        actuator = single.actuator
+        actuator.actuator_type = actuator_type
+        actuator.actuator_name = "test"
+        actuator.id = 1
+        actuator.comm.comm_type = comm_pb2.BLE
+        actuator.spike_motor_config.port = "A"
+        if actuator_type == action_pb2.ActuatorType.MOCK_MOTOR:
+            actuator.mock_motor_config.motor_id = 1
+        return single
+
+    def test_mock_driver(self):
+        single = self._make_single_action(action_pb2.ActuatorType.MOCK_MOTOR)
+        driver = action_factory.create_action(single)
+        self.assertIsInstance(driver, MockDriver)
+
+    def test_spike_motor_driver(self):
+        single = self._make_single_action(action_pb2.ActuatorType.SPIKE_MOTOR)
+        with mock.patch.object(
+            action_factory, "PybricksMotorDriver", autospec=True
+        ) as patched:
+            instance = patched.return_value
+            driver = action_factory.create_action(single)
+            patched.assert_called_once()
+            instance.init.assert_called_once()
+            self.assertEqual(driver, instance)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/robot/action/motors/drivers/BUILD
+++ b/robot/action/motors/drivers/BUILD
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 cc_library(
     name = "sts3215_driver",
@@ -22,5 +22,29 @@ py_library(
         "//robot/action/interfaces:actuator_interface_py",
         "//robot/action/proto:action_packet_py_proto",
         "//robot/action/proto:action_py_proto",
+    ],
+)
+
+py_library(
+    name = "pybricks_driver_py",
+    srcs = ["pybricks_driver.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//robot/action/interfaces:actuator_interface_py",
+        "//robot/action/proto:action_packet_py_proto",
+        "//robot/action/proto:action_py_proto",
+        "//robot/comm:pybricks_ble_transport_py",
+        "//robot/comm/proto:comm_py_proto",
+    ],
+)
+
+py_test(
+    name = "pybricks_driver_test",
+    srcs = ["pybricks_driver_test.py"],
+    deps = [
+        ":pybricks_driver_py",
+        "//robot/action/proto:action_packet_py_proto",
+        "//robot/action/proto:action_py_proto",
+        "//robot/comm/proto:comm_py_proto",
     ],
 )

--- a/robot/action/motors/drivers/pybricks_driver.py
+++ b/robot/action/motors/drivers/pybricks_driver.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+from robot.action.interfaces.actuator_interface import ActuatorInterface
+from robot.action.proto import action_packet_pb2, action_pb2
+from robot.comm.proto import comm_pb2
+
+
+class SpikeTransport(Protocol):
+    def connect(self, hub_id: Optional[str]) -> None:
+        raise NotImplementedError
+
+    def disconnect(self, hub_id: Optional[str]) -> None:
+        raise NotImplementedError
+
+    def set_motor_angle(self, hub_id: Optional[str], port: str, angle: float) -> None:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class SpikeMotorSpec:
+    hub_id: Optional[str]
+    port: str
+
+
+class PybricksMotorDriver(ActuatorInterface):
+    def __init__(
+        self,
+        actuator: action_pb2.Actuator,
+        transport: Optional[SpikeTransport] = None,
+    ) -> None:
+        self._actuator = actuator
+        self._spec = self._parse_spec(actuator)
+        self._owns_transport = False
+        if transport is None:
+            from robot.comm.pybricks_ble_transport import PybricksBleTransport
+
+            transport = PybricksBleTransport.get_shared(self._spec.hub_id)
+            self._owns_transport = True
+        self._transport = transport
+
+    def init(self) -> None:
+        self._transport.connect(self._spec.hub_id)
+
+    def get_id(self) -> str:
+        hub = self._spec.hub_id or "default"
+        return f"spike_motor:{hub}:{self._spec.port}"
+
+    def set_action(self, action_packet: action_packet_pb2.ActionPacket) -> None:
+        angle = float(action_packet.position)
+        self._transport.set_motor_angle(self._spec.hub_id, self._spec.port, angle)
+
+    def teardown(self) -> None:
+        if self._owns_transport:
+            from robot.comm.pybricks_ble_transport import PybricksBleTransport
+
+            PybricksBleTransport.release_shared(self._spec.hub_id)
+        else:
+            self._transport.disconnect(self._spec.hub_id)
+
+    @staticmethod
+    def _parse_spec(actuator: action_pb2.Actuator) -> SpikeMotorSpec:
+        if actuator.actuator_type != action_pb2.ActuatorType.SPIKE_MOTOR:
+            raise ValueError("Actuator type must be SPIKE_MOTOR")
+
+        if actuator.comm.comm_type != comm_pb2.BLE:
+            raise ValueError("SPIKE_MOTOR requires comm_type BLE")
+
+        config = actuator.spike_motor_config
+        if not config.port:
+            raise ValueError("SpikeMotorConfig.port must be set (e.g., 'A')")
+
+        hub_id = config.hub_id or None
+        return SpikeMotorSpec(hub_id=hub_id, port=config.port)

--- a/robot/action/motors/drivers/pybricks_driver_test.py
+++ b/robot/action/motors/drivers/pybricks_driver_test.py
@@ -1,0 +1,67 @@
+import unittest
+
+from robot.action.motors.drivers.pybricks_driver import PybricksMotorDriver
+from robot.action.proto import action_packet_pb2, action_pb2
+from robot.comm.proto import comm_pb2
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.connected = []
+        self.disconnected = []
+        self.commands = []
+
+    def connect(self, hub_id):
+        self.connected.append(hub_id)
+
+    def disconnect(self, hub_id):
+        self.disconnected.append(hub_id)
+
+    def set_motor_angle(self, hub_id, port, angle):
+        self.commands.append((hub_id, port, angle))
+
+
+class PybricksMotorDriverTest(unittest.TestCase):
+    """Unit tests for PybricksMotorDriver using a fake transport (no hardware)."""
+    def _make_actuator(self, hub_id: str = "", port: str = "A"):
+        actuator = action_pb2.Actuator()
+        actuator.actuator_name = "spike_motor_A"
+        actuator.id = 1
+        actuator.actuator_type = action_pb2.ActuatorType.SPIKE_MOTOR
+        actuator.comm.comm_type = comm_pb2.BLE
+        actuator.spike_motor_config.hub_id = hub_id
+        actuator.spike_motor_config.port = port
+        return actuator
+
+    def test_init_set_action_teardown(self):
+        transport = FakeTransport()
+        actuator = self._make_actuator(hub_id="hub-1", port="A")
+        driver = PybricksMotorDriver(actuator, transport=transport)
+
+        driver.init()
+        self.assertEqual(transport.connected, ["hub-1"])
+
+        packet = action_packet_pb2.ActionPacket()
+        packet.position = 42.0
+        driver.set_action(packet)
+        self.assertEqual(transport.commands, [("hub-1", "A", 42.0)])
+
+        driver.teardown()
+        self.assertEqual(transport.disconnected, ["hub-1"])
+
+    def test_requires_ble_comm(self):
+        transport = FakeTransport()
+        actuator = self._make_actuator()
+        actuator.comm.comm_type = comm_pb2.SERIAL
+        with self.assertRaises(ValueError):
+            PybricksMotorDriver(actuator, transport=transport)
+
+    def test_requires_port(self):
+        transport = FakeTransport()
+        actuator = self._make_actuator(port="")
+        with self.assertRaises(ValueError):
+            PybricksMotorDriver(actuator, transport=transport)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/robot/action/proto/action.proto
+++ b/robot/action/proto/action.proto
@@ -15,6 +15,7 @@ enum ActuatorType {
   ACTUATOR_INVALID = 0;
   STS3215_SERVO = 1;
   MOCK_MOTOR = 2;
+  SPIKE_MOTOR = 3;
 }
 
 message Actuator {
@@ -31,6 +32,7 @@ message Actuator {
   oneof action_config {
     Sts3215Config sts3215_config = 11;
     MockMotorConfig mock_motor_config = 12;
+    SpikeMotorConfig spike_motor_config = 13;
     // Add other motor type here.
   }
 }
@@ -44,6 +46,11 @@ message Sts3215Config {
 
 message MockMotorConfig {
   uint64 motor_id = 1;
+}
+
+message SpikeMotorConfig {
+  string hub_id = 1;
+  string port = 2;
 }
 
 message SingleAction {

--- a/robot/comm/BUILD
+++ b/robot/comm/BUILD
@@ -1,0 +1,8 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "pybricks_ble_transport_py",
+    srcs = ["pybricks_ble_transport.py"],
+)

--- a/robot/comm/proto/comm.proto
+++ b/robot/comm/proto/comm.proto
@@ -6,6 +6,7 @@ package robot.comm;
 enum CommType {
   COMM_INVALID = 0;
   SERIAL = 1;
+  BLE = 2;
 }
 
 message Comm {

--- a/robot/comm/pybricks_ble_transport.py
+++ b/robot/comm/pybricks_ble_transport.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import threading
+from typing import Optional
+
+
+_PROGRAM_SOURCE = """\
+from pybricks.hubs import PrimeHub
+from pybricks.pupdevices import Motor
+from pybricks.parameters import Port, Stop
+import usys as sys
+
+_PORT_MAP = {
+    "A": Port.A,
+    "B": Port.B,
+    "C": Port.C,
+    "D": Port.D,
+    "E": Port.E,
+    "F": Port.F,
+}
+
+_motors = {}
+
+def _get_motor(port_name: str):
+    if port_name in _motors:
+        return _motors[port_name]
+    port = _PORT_MAP.get(port_name)
+    if port is None:
+        return None
+    try:
+        motor = Motor(port)
+    except Exception:
+        return None
+    _motors[port_name] = motor
+    return motor
+
+def _set_angle(port_name: str, angle: float):
+    motor = _get_motor(port_name)
+    if motor is None:
+        print("ERR no_motor", port_name)
+        return
+    try:
+        motor.run_target(500, angle, then=Stop.HOLD, wait=False)
+        print("OK", port_name, angle)
+    except Exception as exc:
+        print("ERR set_failed", port_name, repr(exc))
+
+print("READY")
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        continue
+    parts = line.strip().split()
+    if len(parts) == 3 and parts[0] == "SET":
+        try:
+            _set_angle(parts[1], float(parts[2]))
+        except Exception as exc:
+            print("ERR set_failed", parts, repr(exc))
+            pass
+"""
+
+
+class _AsyncRunner:
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+
+    def run(self, coro):
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    def close(self) -> None:
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=2)
+
+
+class PybricksBleTransport:
+    _shared = {}
+
+    @classmethod
+    def get_shared(cls, hub_id: Optional[str]) -> "PybricksBleTransport":
+        key = hub_id or ""
+        if key not in cls._shared:
+            cls._shared[key] = {"transport": cls(), "refcount": 0}
+        cls._shared[key]["refcount"] += 1
+        return cls._shared[key]["transport"]
+
+    @classmethod
+    def release_shared(cls, hub_id: Optional[str]) -> None:
+        key = hub_id or ""
+        entry = cls._shared.get(key)
+        if entry is None:
+            return
+        entry["refcount"] -= 1
+        if entry["refcount"] <= 0:
+            entry["transport"].disconnect(hub_id)
+            cls._shared.pop(key, None)
+
+    def __init__(self) -> None:
+        self._runner = _AsyncRunner()
+        self._hub = None
+        self._hub_id: Optional[str] = None
+        self._program_path: Optional[str] = None
+
+    def connect(self, hub_id: Optional[str]) -> None:
+        if self._hub is not None:
+            if self._hub_id != hub_id:
+                raise RuntimeError("Transport already connected to a different hub_id")
+            return
+        self._hub_id = hub_id
+        self._hub = self._runner.run(self._connect_async(hub_id))
+
+    def disconnect(self, hub_id: Optional[str]) -> None:
+        if self._hub is None:
+            return
+        if self._hub_id != hub_id:
+            raise RuntimeError("Transport hub_id mismatch during disconnect")
+        self._runner.run(self._hub.disconnect())
+        self._hub = None
+        self._hub_id = None
+        self._runner.close()
+
+    def set_motor_angle(self, hub_id: Optional[str], port: str, angle: float) -> None:
+        if self._hub is None:
+            raise RuntimeError("Transport is not connected")
+        if self._hub_id != hub_id:
+            raise RuntimeError("Transport hub_id mismatch during command")
+        self._runner.run(self._hub.write_line(f"SET {port} {angle}"))
+
+    async def _connect_async(self, hub_id: Optional[str]):
+        try:
+            from pybricksdev.ble import find_device
+            from pybricksdev.connections.pybricks import PybricksHubBLE
+        except Exception as exc:
+            raise RuntimeError("pybricksdev BLE dependencies are not available") from exc
+
+        device = await find_device(name=hub_id)
+        hub = PybricksHubBLE(device)
+        await hub.connect()
+        await hub.run(
+            self._ensure_program_path(),
+            wait=False,
+            print_output=True,
+            line_handler=True,
+        )
+        await asyncio.sleep(0.5)
+        return hub
+
+    def _ensure_program_path(self) -> str:
+        if self._program_path is None:
+            handle = tempfile.NamedTemporaryFile(
+                mode="w", prefix="pybricks_driver_", suffix=".py", delete=False
+            )
+            handle.write(_PROGRAM_SOURCE)
+            handle.flush()
+            self._program_path = handle.name
+            handle.close()
+        return self._program_path

--- a/ros2/BUILD
+++ b/ros2/BUILD
@@ -1,5 +1,5 @@
 # System ROS2 rules (using system-installed ROS2 libraries)
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("//:requirements.bzl", "requirement")
 load("//:system_ros2_rules.bzl", "ros2_cpp_binary", "ros2_py_binary")
 
@@ -42,6 +42,7 @@ py_library(
     ],
     visibility = ["//visibility:public"],
 )
+
 
 ros2_py_binary(
     name = "inference",
@@ -223,6 +224,19 @@ ros2_py_binary(
         "//robot/action/proto:action_packet_py_proto",
         "//robot/perception/proto:perception_py_proto",
         "//ros2:node_runner_py",
+        "//ros2/utils:qos_setting_py",
+        "//ros2/proto:node_py_proto",
+    ] + requirement("protobuf"),
+)
+
+py_test(
+    name = "actuator_subscriber_test",
+    srcs = ["actuator_subscriber_test.py"],
+    deps = [
+        "//config/proto:config_py_proto",
+        "//robot/action/proto:action_py_proto",
+        "//robot/perception/proto:perception_py_proto",
+        "//robot/action/factory:action_factory_py",
         "//ros2/utils:qos_setting_py",
         "//ros2/proto:node_py_proto",
     ] + requirement("protobuf"),

--- a/ros2/actuator_subscriber.py
+++ b/ros2/actuator_subscriber.py
@@ -29,6 +29,7 @@ class ActuatorEntry:
         self.encoder_data_mode = encoder_data_mode
         self.mapping = self._compute_mapping()
         self.subscription = None
+        self.callback = None
 
     def _compute_mapping(self) -> MappingParams:
         lower, upper = self.limits
@@ -92,10 +93,11 @@ class ActionSubscriber(Node):
                         encoder_data_mode=actuator_proto.encoder_data_mode,
                     )
                     self._actuators.append(entry)
+                    entry.callback = self._make_callback(entry)
                     entry.subscription = self.create_subscription(
                         Float32,
                         entry.topic,
-                        self._make_callback(entry),
+                        entry.callback,
                         create_qos_setting(qos_setting),
                     )
 

--- a/ros2/actuator_subscriber_test.py
+++ b/ros2/actuator_subscriber_test.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest import mock
+
+
+class ActuatorSubscriberTest(unittest.TestCase):
+    """Regression test for actuator subscriber callback wiring without hardware."""
+    def test_callback_mapping_raw(self):
+        try:
+            import rclpy
+        except Exception as exc:
+            self.skipTest(f"rclpy not available: {exc}")
+
+        from config.proto import config_pb2
+        from robot.action.proto import action_pb2
+        from robot.perception.proto import perception_pb2
+        from actuator_subscriber import ActionSubscriber
+        from std_msgs.msg import Float32
+
+        class FakeDriver:
+            def __init__(self):
+                self.last_packet = None
+
+            def init(self):
+                pass
+
+            def set_action(self, packet):
+                self.last_packet = packet
+
+            def teardown(self):
+                pass
+
+        rclpy.init(args=[])
+        try:
+            fake_driver = FakeDriver()
+
+            def fake_create_action(_):
+                return fake_driver
+
+            cfg = config_pb2.Config()
+            cfg.general.name = "test"
+            cfg.general.id = 1
+            action = cfg.robot.actions.single_actions.add()
+            action.action_type = action_pb2.ActionType.ACTUATOR
+            action.node.id = 123
+            action.node.node_type = action.node.ACTUATOR_SUBSCRIBER
+            action.node.qos_setting.depth = 1
+            sub = action.node.subscriptions.add()
+            sub.ros2_data_type = sub.ROS2_DATA_TYPE_FLOAT32
+            sub.topic = "spike/motor_A/command"
+            actuator = action.actuator
+            actuator.actuator_name = "spike_motor_A"
+            actuator.id = 1
+            actuator.actuator_type = action_pb2.ActuatorType.MOCK_MOTOR
+            actuator.mock_motor_config.motor_id = 1
+            actuator.operational_lower_limit = 0
+            actuator.operational_upper_limit = 1000
+            actuator.encoder_data_mode = perception_pb2.ENCODER_DATA_MODE_RAW
+
+            with mock.patch(
+                "ros2.actuator_subscriber.action_factory.create_action",
+                side_effect=fake_create_action,
+            ):
+                node = ActionSubscriber("actuator_subscriber", 123, cfg)
+                try:
+                    self.assertEqual(len(node._actuators), 1)
+                    entry = node._actuators[0]
+                    msg = Float32()
+                    msg.data = 42.0
+                    entry.callback(msg)
+                    self.assertIsNotNone(fake_driver.last_packet)
+                    self.assertEqual(fake_driver.last_packet.position, 42.0)
+                finally:
+                    node.shutdown()
+                    node.destroy_node()
+        finally:
+            if rclpy.ok():
+                rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pybricks_spike_bridge.py
+++ b/scripts/pybricks_spike_bridge.py
@@ -1,0 +1,95 @@
+"""
+Simple Pybricks program to bridge ROS commands to a Spike Prime motor.
+Protocol (line-based over stdin/stdout):
+- SET <PORT> <VALUE>: sets motor duty cycle on the given port (A-F), VALUE in [-1.0, 1.0].
+  Replies: OK or ERR
+- GET <PORT>: reads motor angle in degrees from the given port.
+  Replies: <float> or ERR
+Run this on the hub via the Pybricks app or pybricksdev, then start the Python bridge
+with PYTHON_BRIDGE_BACKEND=pybricks PYBRICKS_TRANSPORT=usb and publish Float32 commands
+to the configured topic (e.g., spike/motor_A/command).
+"""
+
+from pybricks.hubs import PrimeHub
+from pybricks.pupdevices import Motor
+from pybricks.parameters import Color, Port
+
+# Micropython on the hub may expose sys as usys; try both.
+try:
+    import sys  # type: ignore
+except ImportError:  # pragma: no cover
+    import usys as sys  # type: ignore
+
+
+hub = PrimeHub()
+hub.light.on(Color.GREEN)
+
+PORT_MAP = {
+    "A": Port.A,
+    "B": Port.B,
+    "C": Port.C,
+    "D": Port.D,
+    "E": Port.E,
+    "F": Port.F,
+}
+
+# Cache motor instances for connected ports to avoid recreating on each command.
+MOTORS = {}
+for name, port in PORT_MAP.items():
+    try:
+        MOTORS[name] = Motor(port)
+    except Exception:
+        pass
+
+
+def get_motor(port_name: str) -> Motor | None:
+    return MOTORS.get(port_name.upper())
+
+
+def handle_set(port: str, value_str: str) -> str:
+    motor = get_motor(port)
+    if not motor:
+        return "ERR"
+    try:
+        value = float(value_str)
+        # Clamp to [-1.0, 1.0] duty cycle
+        value = max(-1.0, min(1.0, value))
+        motor.dc(int(value * 100))
+        return "OK"
+    except Exception:
+        return "ERR"
+
+
+def handle_get(port: str) -> str:
+    motor = get_motor(port)
+    if not motor:
+        return "ERR"
+    try:
+        return str(float(motor.angle()))
+    except Exception:
+        return "ERR"
+
+
+def main() -> None:
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            continue
+        parts = line.strip().split()
+        if not parts:
+            print("ERR")
+            sys.stdout.flush()
+            continue
+        cmd = parts[0].upper()
+        if cmd == "SET" and len(parts) == 3:
+            resp = handle_set(parts[1], parts[2])
+        elif cmd == "GET" and len(parts) == 2:
+            resp = handle_get(parts[1])
+        else:
+            resp = "ERR"
+        print(resp)
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/spike_wave_publisher.py
+++ b/scripts/spike_wave_publisher.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import argparse
+import math
+import time
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Float32
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Publish sine wave to a ROS topic.")
+    parser.add_argument(
+        "--topic",
+        default="spike/motor_A/command",
+        help="ROS topic to publish to",
+    )
+    parser.add_argument("--offset", type=float, default=90.0, help="Angle offset")
+    parser.add_argument("--amplitude", type=float, default=45.0, help="Wave amplitude")
+    parser.add_argument("--hz", type=float, default=20.0, help="Publish rate (Hz)")
+    parser.add_argument("--omega", type=float, default=1.0, help="Wave speed (rad/s)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    rclpy.init()
+    node = Node("spike_wave")
+    pub = node.create_publisher(Float32, args.topic, 10)
+    t0 = time.time()
+    try:
+        while True:
+            msg = Float32()
+            msg.data = args.offset + args.amplitude * math.sin(
+                (time.time() - t0) * args.omega
+            )
+            pub.publish(msg)
+            time.sleep(1.0 / args.hz)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pybricks/BUILD
+++ b/tools/pybricks/BUILD
@@ -1,0 +1,14 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "pybricks_ble_smoke",
+    srcs = ["pybricks_ble_smoke.py"],
+    deps = [
+        "//robot/action/motors/drivers:pybricks_driver_py",
+        "//robot/action/proto:action_packet_py_proto",
+        "//robot/action/proto:action_py_proto",
+        "//robot/comm/proto:comm_py_proto",
+    ],
+)

--- a/tools/pybricks/pybricks_ble_smoke.py
+++ b/tools/pybricks/pybricks_ble_smoke.py
@@ -1,0 +1,48 @@
+import sys
+import time
+
+from robot.action.motors.drivers.pybricks_driver import PybricksMotorDriver
+from robot.action.proto import action_packet_pb2, action_pb2
+from robot.comm.proto import comm_pb2
+
+
+def _usage() -> None:
+    print("Usage: pybricks_ble_smoke <hub_id_or_empty> <port> <angle>")
+    print("Example: pybricks_ble_smoke SPIKE  A  90")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        _usage()
+        return 2
+
+    hub_id = argv[1]
+    port = argv[2]
+    try:
+        angle = float(argv[3])
+    except ValueError:
+        _usage()
+        return 2
+
+    actuator = action_pb2.Actuator()
+    actuator.actuator_name = "spike_motor"
+    actuator.id = 1
+    actuator.actuator_type = action_pb2.ActuatorType.SPIKE_MOTOR
+    actuator.comm.comm_type = comm_pb2.BLE
+    actuator.spike_motor_config.hub_id = hub_id if hub_id != "''" else ""
+    actuator.spike_motor_config.port = port
+
+    driver = PybricksMotorDriver(actuator)
+    driver.init()
+
+    packet = action_packet_pb2.ActionPacket()
+    packet.position = angle
+    driver.set_action(packet)
+    time.sleep(1.0)
+
+    driver.teardown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
- Introduced SPIKE_MOTOR actuator type in action.proto and corresponding SpikeMotorConfig message.
- Implemented PybricksMotorDriver to control motors via BLE.
- Added action_factory_test to validate action creation for both MockDriver and PybricksMotorDriver.
- Created pybricks_driver_test to unit test the PybricksMotorDriver functionality.
- Developed a BLE transport layer for communication with Pybricks motors.
- Updated actuator_subscriber to handle new SPIKE_MOTOR type.
- Added example configuration for SPIKE motors in python_spike_actuator_example.pbtxt.
- Created documentation for Pybricks testing and usage.
- Implemented smoke test script for quick validation of motor commands.

## Summary

Support PyBricks using the new python HW layer

## Tested

Verified two motors connected on port A and B move. (see video on Slack)
