### PR TITLE
Docker image for Mac Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ ui/public/proto-schema*
 
 # Build output
 dist/
+
+# Ignore MAC OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Joshua Control Panel (Qt6 C++ GUI) ties it together: you can create or load 
   Follow the link below to complete gpg key setup. 
   [gpg key link setup](https://docs.docker.com/desktop/setup/sign-in/#credentials-management-for-linux-users)
 - **Build Docker Image:** Run the docker command to build the image in need. 
-  [ubuntu 22.04 base with ROS2 humble]
+  [Linux Host: ubuntu 22.04 base with ROS2 humble]
   ```bash
   docker compose build joshua-u22
   ```
@@ -31,11 +31,16 @@ The Joshua Control Panel (Qt6 C++ GUI) ties it together: you can create or load 
   ```bash
   docker compose build joshua-u22-arm64
   ```
-  [ubuntu 24.04 base with ROS2 jazzy]
+  [Linux Host: ubuntu 24.04 base with ROS2 jazzy]
   ```bash
   docker compose build joshua-u24
   ```
   arm64 image for joshua-u24 is available as well. 
+  [Mac Apple Silicon Host: ubuntu 22.04 base with ROS2 humble]
+  ```bash
+  docker compose build joshua-mac-u22-arm64
+  ```
+  Note: Docker image for MAC supports arm64 target build only. Also serial ports are mocked by default. If real serial ports are needed, refer to the comments in docker-compose.yml file for details. 
 - **Run interactive shell:**
   [ubuntu 22.04 base with ROS2 humble]
   ```bash

--- a/README.md
+++ b/README.md
@@ -44,11 +44,15 @@ The Joshua Control Panel (Qt6 C++ GUI) ties it together: you can create or load 
 - **Run interactive shell:**
   [ubuntu 22.04 base with ROS2 humble]
   ```bash
-  docker compose run --rm joshua-u22
+  docker compose run joshua-u22
   ```
   [ubuntu 24.04 base with ROS2 jazzy]
   ```bash
-  docker compose run --rm joshua-u24
+  docker compose run joshua-u24
+  ```
+  [Mac Host ubuntu 22.04 base with ROS2 humble arm64 target]
+  ```bash
+  docker compose run joshua-mac-u22-arm64
   ```
   To exit, type exit.
   After exiting, resume the docker container with the container name. 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Joshua Control Panel (Qt6 C++ GUI) ties it together: you can create or load 
 
 ### Option A: Build docker image and run
 
-- **Operating System:** Ubuntu 22.04 LTS
+- **Operating System:** Ubuntu or MAC Apple Silicon
 - **Install Docker:** Install docker desktop for your host machine and run. 
 - **(Linux Only) Login with gpg key** Docker desktop requires gpg key credentials for linux users.
   Follow the link below to complete gpg key setup. 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The Joshua Control Panel (Qt6 C++ GUI) ties it together: you can create or load 
 ### Option A: Build docker image and run
 
 - **Operating System:** Ubuntu 22.04 LTS
-- **Install Docker:** Install docker with the following command
-  ```bash
-  sudo apt install docker.io
-  ```
+- **Install Docker:** Install docker desktop for your host machine and run. 
+- **(Linux Only) Login with gpg key** Docker desktop requires gpg key credentials for linux users.
+  Follow the link below to complete gpg key setup. 
+  [gpg key link setup](https://docs.docker.com/desktop/setup/sign-in/#credentials-management-for-linux-users)
 - **Build Docker Image:** Run the docker command to build the image in need. 
   [ubuntu 22.04 base with ROS2 humble]
   ```bash
@@ -46,13 +46,18 @@ The Joshua Control Panel (Qt6 C++ GUI) ties it together: you can create or load 
   docker compose run --rm joshua-u24
   ```
   To exit, type exit.
-  After exiting, resume the docker container with:
+  After exiting, resume the docker container with the container name. 
+  To query stopped docker container list, type
   ```bash
-  docker start -i joshua-u22
+  docker container list -a
   ```
-  or 
+  To resume stopped docker, do
   ```bash
-  docker start -i jushua-u24
+  docker start -ai [container_name]
+  ```
+  For example, the resume command would look like
+  ```bash
+  docker start -ai joshua-joshua-u22-run-a199afce4b8a
   ```
 
 ### Option B: Native Installation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,12 @@
 # Build for ARM64 (cross-platform):
 #   docker compose build joshua-u22-arm64   # Build Ubuntu 22.04 for ARM64
 #   docker compose build joshua-u24-arm64   # Build Ubuntu 24.04 for ARM64
+#   docker compose build joshua-mac-u22-arm64  # Build Ubuntu 22.04 for ARM64 (macOS optimized with mock serial ports)
 #
 # Run containers:
 #   docker compose run --rm joshua-u22      # Interactive shell (Ubuntu 22.04 + Humble)
 #   docker compose run --rm joshua-u24      # Interactive shell (Ubuntu 24.04 + Jazzy)
+#   docker compose run --rm joshua-mac-u22-arm64  # Interactive shell (Ubuntu 22.04 + Humble, macOS optimized)
 #
 # Run with Bazel target:
 #   docker compose run --rm joshua-u22 bazel run launcher:joshua_main
@@ -100,6 +102,41 @@ services:
     profiles:
       - arm64  # Only build when explicitly requested
 
+  # Ubuntu 22.04 + ROS2 Humble + Python 3.10 for ARM64 (macOS optimized)
+  # This service includes mock serial port support for development on macOS
+  # Note: Use profile 'arm64' or 'mac' to build this service
+  joshua-mac-u22-arm64:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.ubuntu22
+      platforms:
+        - linux/arm64
+    image: joshua:u22-humble-mac-arm64
+    container_name: joshua-mac-u22-arm64-dev
+    stdin_open: true
+    tty: true
+    privileged: true
+    network_mode: host
+    volumes:
+      - .:/workspace
+      # Note: /dev:/dev is NOT mounted by default for macOS because:
+      # 1. macOS device names (/dev/tty.*, /dev/cu.*) don't match Linux names (/dev/ttyACM*, /dev/ttyUSB*)
+      # 2. Mounting /dev prevents creating mock serial ports in the container
+      # To mount /dev for real device access, uncomment the line below:
+      # - /dev:/dev
+      - bazel-cache-u22-mac-arm64:/root/.cache/bazel
+    environment:
+      - ROS_DISTRO=humble
+      - DISPLAY=${DISPLAY:-}
+      # Set to "true" to automatically create mock serial ports for development
+      # Mock ports allow the application to run without physical serial devices
+      - ENABLE_MOCK_SERIAL_PORTS=${ENABLE_MOCK_SERIAL_PORTS:-true}
+    entrypoint: ["/workspace/scripts/docker_entrypoint.sh"]
+    working_dir: /workspace
+    profiles:
+      - arm64  # Only build when explicitly requested
+      - mac    # macOS-specific profile
+
   # Ubuntu 24.04 + ROS2 Jazzy + Python 3.12 for ARM64 (Experimental)
   # Note: Use profile 'arm64' to build these services (requires cross-platform build support)
   joshua-u24-arm64:
@@ -144,4 +181,5 @@ volumes:
   bazel-cache-u22:
   bazel-cache-u24:
   bazel-cache-u22-arm64:
+  bazel-cache-u22-mac-arm64:
   bazel-cache-u24-arm64:

--- a/dockerfiles/Dockerfile.ubuntu22
+++ b/dockerfiles/Dockerfile.ubuntu22
@@ -95,6 +95,7 @@ RUN apt-get update && apt-get install -y \
 # ============================================
 RUN apt-get update && apt-get install -y \
     libevdev-dev \
+    socat \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================
@@ -139,8 +140,22 @@ RUN apt-get update && apt-get install -y \
 # Install Python Project Dependencies
 # ============================================
 COPY requirements.lock /tmp/requirements.lock
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install --no-deps -r /tmp/requirements.lock && \
+# Filter out packages not available for ARM64 builds
+# - torchcodec: not available for ARM64 (only 0.0.0.dev0 exists)
+# - triton: GPU kernel compiler, not needed for ARM64 Mac builds (CUDA not available)
+# For ARM64, allow pip to resolve dependencies (don't use --no-deps) to handle missing packages gracefully
+# Also deduplicate packages (keep first occurrence) to handle duplicate entries like tzdata
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        grep -v "^torchcodec==" /tmp/requirements.lock | \
+        grep -v "^triton==" | \
+        awk -F'==' '!seen[$1]++' > /tmp/requirements_filtered.lock && \
+        mv /tmp/requirements_filtered.lock /tmp/requirements.lock && \
+        python3 -m pip install --upgrade pip && \
+        python3 -m pip install -r /tmp/requirements.lock; \
+    else \
+        python3 -m pip install --upgrade pip && \
+        python3 -m pip install --no-deps -r /tmp/requirements.lock; \
+    fi && \
     rm /tmp/requirements.lock
 
 # Fix for missing NVIDIA libraries in torch

--- a/dockerfiles/Dockerfile.ubuntu22
+++ b/dockerfiles/Dockerfile.ubuntu22
@@ -140,20 +140,25 @@ RUN apt-get update && apt-get install -y \
 # Install Python Project Dependencies
 # ============================================
 COPY requirements.lock /tmp/requirements.lock
-# Filter out packages not available for ARM64 builds
-# - torchcodec: not available for ARM64 (only 0.0.0.dev0 exists)
-# - triton: GPU kernel compiler, not needed for ARM64 Mac builds (CUDA not available)
-# For ARM64, allow pip to resolve dependencies (don't use --no-deps) to handle missing packages gracefully
-# Also deduplicate packages (keep first occurrence) to handle duplicate entries like tzdata
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
+# Filter Python requirements in a way that works for both AMD64 and ARM64:
+# - Always deduplicate packages (keep first occurrence) to handle duplicate entries like tzdata.
+# - On ARM64, additionally filter out:
+#   - torchcodec: not available for ARM64 (only 0.0.0.dev0 exists).
+#   - triton: GPU kernel compiler, not needed for ARM64 Mac builds (CUDA not available).
+# - On ARM64, allow pip to resolve dependencies (don't use --no-deps) to handle missing packages gracefully.
+# - On AMD64, keep the original behavior of installing with --no-deps for reproducibility.
+RUN python3 -m pip install --upgrade pip && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
         grep -v "^torchcodec==" /tmp/requirements.lock | \
         grep -v "^triton==" | \
-        awk -F'==' '!seen[$1]++' > /tmp/requirements_filtered.lock && \
-        mv /tmp/requirements_filtered.lock /tmp/requirements.lock && \
-        python3 -m pip install --upgrade pip && \
+        awk -F'==' '!seen[$1]++' > /tmp/requirements_filtered.lock; \
+    else \
+        awk -F'==' '!seen[$1]++' /tmp/requirements.lock > /tmp/requirements_filtered.lock; \
+    fi && \
+    mv /tmp/requirements_filtered.lock /tmp/requirements.lock && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
         python3 -m pip install -r /tmp/requirements.lock; \
     else \
-        python3 -m pip install --upgrade pip && \
         python3 -m pip install --no-deps -r /tmp/requirements.lock; \
     fi && \
     rm /tmp/requirements.lock

--- a/scripts/create_mock_serial_ports.sh
+++ b/scripts/create_mock_serial_ports.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Script to create mock serial ports for development/testing
+# This is useful when running in Docker without physical serial devices
+# Creates PTY pairs using socat that can be used as serial ports
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Ports to create (from common config files)
+PORTS=("/dev/ttyACM0" "/dev/ttyACM1" "/dev/ttyUSB0")
+
+# Function to check if port exists
+port_exists() {
+    [ -e "$1" ]
+}
+
+# Function to create mock serial port using socat
+create_mock_port() {
+    local port=$1
+    
+    if port_exists "$port"; then
+        echo -e "${YELLOW}Port $port already exists, skipping...${NC}"
+        return 0
+    fi
+    
+    echo -e "${GREEN}Creating mock serial port: $port${NC}"
+    
+    # Check if /dev is mounted from host (macOS)
+    # If /dev is mounted, we need to create the port differently
+    if mountpoint -q /dev 2>/dev/null; then
+        echo -e "${YELLOW}Warning: /dev appears to be mounted from host.${NC}"
+        echo -e "${YELLOW}Creating PTY and attempting to create symlink...${NC}"
+    fi
+    
+    # Create PTY pair using socat
+    # This creates a bidirectional pipe that looks like a serial port
+    # The link= option creates a symlink to the PTY
+    # Use -d -d for minimal output, redirect stderr to avoid noise
+    socat -d -d pty,raw,echo=0,link="$port" pty,raw,echo=0 2>/dev/null &
+    local socat_pid=$!
+    
+    # Wait a moment for the symlink to be created
+    sleep 1
+    
+    if port_exists "$port"; then
+        echo -e "${GREEN}Successfully created $port (socat PID: $socat_pid)${NC}"
+        # Store PID for cleanup
+        echo "$socat_pid" >> /tmp/mock_serial_pids.txt
+        return 0
+    else
+        # If symlink creation failed (e.g., /dev is mounted from host),
+        # try creating it manually if we have permissions
+        echo -e "${YELLOW}Symlink creation may have failed. Checking PTY...${NC}"
+        # Find the PTY that socat created
+        local pty=$(ps -p $socat_pid -o args= | grep -o '/dev/pts/[0-9]*' | head -1)
+        if [ -n "$pty" ] && [ -e "$pty" ]; then
+            echo -e "${YELLOW}Found PTY: $pty, attempting manual symlink...${NC}"
+            # Try to create symlink manually (may fail if /dev is mounted read-only or from host)
+            ln -sf "$pty" "$port" 2>/dev/null && echo -e "${GREEN}Manual symlink created${NC}" || \
+                echo -e "${RED}Could not create symlink. Port may not be accessible at $port${NC}"
+        fi
+        # Store PID anyway for cleanup
+        echo "$socat_pid" >> /tmp/mock_serial_pids.txt
+        return 1
+    fi
+}
+
+# Main execution
+echo -e "${GREEN}Setting up mock serial ports for development...${NC}"
+
+# Check if socat is available
+if ! command -v socat &> /dev/null; then
+    echo -e "${RED}Error: socat is not installed. Please install it first.${NC}"
+    echo "  apt-get update && apt-get install -y socat"
+    exit 1
+fi
+
+# Create PID file for cleanup
+rm -f /tmp/mock_serial_pids.txt
+touch /tmp/mock_serial_pids.txt
+
+# Create each port
+for port in "${PORTS[@]}"; do
+    create_mock_port "$port" || true
+done
+
+echo -e "${GREEN}Mock serial ports setup complete!${NC}"
+echo -e "${YELLOW}Note: These are virtual ports for development.${NC}"
+echo -e "${YELLOW}To clean up, run: pkill -f 'socat.*tty'${NC}"
+
+# In background mode, just exit (socat processes will keep running)
+# The ports will persist as long as socat processes run
+if [ "$1" = "--background" ]; then
+    exit 0
+fi
+
+# Keep script running to maintain the ports
+echo -e "${GREEN}Press Ctrl+C to stop and clean up...${NC}"
+trap "echo 'Cleaning up...'; pkill -f 'socat.*tty' 2>/dev/null; exit" INT TERM
+# Keep running
+while true; do sleep 1; done

--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Docker entrypoint script for Joshua containers
+# Creates mock serial ports if they don't exist (for development/testing)
+
+set -e
+
+# If ENABLE_MOCK_SERIAL_PORTS is set, create mock serial ports
+if [ "${ENABLE_MOCK_SERIAL_PORTS:-false}" = "true" ]; then
+    echo "=========================================="
+    echo "Creating mock serial ports for development..."
+    echo "This allows the application to run without physical serial devices."
+    echo "=========================================="
+    /workspace/scripts/create_mock_serial_ports.sh --background || true
+    sleep 1  # Give socat time to create the ports
+    echo "Mock serial ports ready!"
+    echo ""
+fi
+
+# Execute the command passed to the container, or default to bash for interactive use
+if [ $# -eq 0 ]; then
+    # No command provided, start an interactive bash shell
+    exec /bin/bash
+else
+    # Execute the provided command
+    exec "$@"
+fi


### PR DESCRIPTION
## Summary
- New docker image profile added: joshua-mac-u22-arm64
- Docker setup guide update on readme for linux users. 

## Test Guide
- **Operating System:** Ubuntu or MAC Apple Silicon
- **Install Docker:** Install docker desktop for your host machine and run. 
- **(Linux Only) Login with gpg key** Docker desktop requires gpg key credentials for linux users.
  Follow the link below to complete gpg key setup. 
  [gpg key link setup](https://docs.docker.com/desktop/setup/sign-in/#credentials-management-for-linux-users)
- **Build Docker Image:** Run the docker command to build the image in need. 
  [Linux Host: ubuntu 22.04 base with ROS2 humble]
  ```bash
  docker compose build joshua-u22
  ```
  If building for ARM 64, build docker image targeted for arm64. 
  ```bash
  docker compose build joshua-u22-arm64
  ```
  [Linux Host: ubuntu 24.04 base with ROS2 jazzy]
  ```bash
  docker compose build joshua-u24
  ```
  arm64 image for joshua-u24 is available as well. 
  [Mac Apple Silicon Host: ubuntu 22.04 base with ROS2 humble]
  ```bash
  docker compose build joshua-mac-u22-arm64
  ```
  Note: Docker image for MAC supports arm64 target build only. Also serial ports are mocked by default. If real serial ports are needed, refer to the comments in docker-compose.yml file for details. 
- **Run interactive shell:**
  [ubuntu 22.04 base with ROS2 humble]
  ```bash
  docker compose run joshua-u22
  ```
  [ubuntu 24.04 base with ROS2 jazzy]
  ```bash
  docker compose run joshua-u24
  ```
  [Mac Host ubuntu 22.04 base with ROS2 humble arm64 target]
  ```bash
  docker compose run joshua-mac-u22-arm64
  ```
  To exit, type exit.
  After exiting, resume the docker container with the container name. 
  To query stopped docker container list, type
  ```bash
  docker container list -a
  ```
  To resume stopped docker, do
  ```bash
  docker start -ai [container_name]
  ```
  For example, the resume command would look like
  ```bash
  docker start -ai joshua-joshua-u22-run-a199afce4b8a
  ```

## Test Result
Linux Test
<img width="3691" height="1999" alt="image" src="https://github.com/user-attachments/assets/4fd4a187-99b8-4707-a371-b7e2c17e82b7" />
Mac M3 Test Result of launching joshua_main with mock serial ports
<img width="1582" height="1152" alt="image" src="https://github.com/user-attachments/assets/f8c570e0-58cf-446c-85c8-13e0cd11c827" />

