### PR TITLE
Add new robot scaffold script and config templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,15 @@ bazel run //ai/train:trainer -- --config config/config_preset/ant/ant_train_isaa
 | `so100/so100_teleoperate.pbtxt` | Hardware | SO100 teleoperation |
 | `so100/so_arm100_sim_interactive.pbtxt` | MuJoCo | SO-ARM100 interactive sim |
 
-For full documentation on the training pipeline, simulator backends, and how to add new tasks, see [`ai/train/README.md`](ai/train/README.md).
+### Adding a New Robot
+
+Use the scaffold script to generate config presets and documentation for a new robot:
+
+```bash
+python3 scripts/new_robot.py --name my_robot --usd my_robot_isaac.usda
+```
+
+This creates training/eval config presets with all available reward and observation terms documented inline, plus a starter README. See [`ai/train/README.md`](ai/train/README.md) for the full training pipeline documentation.
 
 
 ## Data Type Architecture

--- a/ai/train/README.md
+++ b/ai/train/README.md
@@ -366,29 +366,48 @@ eval {
 How to Add a New Robot
 ----------------------
 
-1. **Create a USD asset** at `simulation/models/my_robot_isaac.usda`
-   describing the robot's bodies, collision geometry, and joints.
-
-2. **Create a `.pbtxt` preset** with `task_config` defining the full
-   environment:
+The fastest way is the scaffold script:
 
 ```bash
-config/config_preset/my_robot/my_robot_train_isaac_full_rsl_rl.pbtxt
+python3 scripts/new_robot.py --name my_robot --usd my_robot_isaac.usda
 ```
 
-The preset must contain:
-- `task_config.robot` -- USD path, initial pose, joint positions, actuator params
-- `task_config.rewards` -- reward terms and weights
-- `task_config.observations` -- observation terms
-- `ppo` / `network` / `sim_physics` / `termination` / `reset` blocks
+This generates:
+- `config/config_preset/my_robot/my_robot_train_isaac.pbtxt` -- training preset
+  with all available rewards/observations documented inline
+- `config/config_preset/my_robot/my_robot_eval_isaac.pbtxt` -- matching eval preset
+- `simulation/models/my_robot/README.md` -- starter documentation
 
-See the existing ant and trileg presets for complete examples.
+Then follow the printed checklist.
+
+### Manual steps (or to understand what the scaffold generates)
+
+1. **Create a USD articulation** at `simulation/models/my_robot_isaac.usda`:
+   - Articulation root on the main body (e.g. torso)
+   - Z-up axis, meter units
+   - Collision geometry on all bodies
+   - Descriptive joint names (they appear in the config)
+
+2. **Create a training preset** (or copy the template):
+
+```bash
+cp config/config_preset/_template_train.pbtxt \
+   config/config_preset/my_robot/my_robot_train_isaac.pbtxt
+```
+
+Fill in the `TODO:` markers:
+- `task_config.robot` -- USD filename, initial pose, joint positions
+- `task_config.rewards` -- reward terms and weights (all terms are
+  listed in the template with descriptions)
+- `task_config.observations` -- observation terms
+- `sim_physics.action_scale` -- tune for your actuators
+- `termination.min_root_height` -- adjust for your robot's height
 
 3. **Run training**:
 
 ```bash
 bazel run //launcher:joshua_main -- \
-    --config config/config_preset/my_robot/my_robot_train_isaac_full_rsl_rl.pbtxt
+    --config config/config_preset/my_robot/my_robot_train_isaac.pbtxt
 ```
 
 4. **Create an eval preset** that mirrors the training config but uses

--- a/config/config_preset/_template_eval.pbtxt
+++ b/config/config_preset/_template_eval.pbtxt
@@ -1,0 +1,120 @@
+# =============================================================================
+# Evaluation config template for a trained robot.
+#
+# This must mirror the training config's task_config, network, sim_physics,
+# termination, and reset blocks exactly so the environment is reconstructed
+# identically.
+#
+# Usage:
+#   1. Copy your training preset's task_config into this eval preset
+#   2. Set checkpoint_path to your trained model
+#   3. Run: bazel run //launcher:joshua_main -- \
+#              --config config/config_preset/<robot>/<robot>_eval_isaac.pbtxt
+# =============================================================================
+
+general {
+  operation_mode: MODE_TRAINING
+  name: "{{ROBOT_NAME}}"                    # TODO: must match training preset
+}
+ai {
+  training {
+    environment: TRAINING_ENV_SIMULATION
+    method: TRAINING_METHOD_EVAL
+    simulator_backend: SIM_BACKEND_ISAAC_SIM
+    eval {
+      algorithm: "rsl_rl"                    # must match training algorithm
+      checkpoint_path: "/tmp/joshua_checkpoints/isaac_logs/{{ROBOT_NAME}}_ppo/model_999.pt"  # TODO: path to trained checkpoint
+      num_episodes: 10
+      num_envs: 4
+      render: true
+
+      # =====================================================================
+      # TASK CONFIG -- must be identical to training preset
+      # =====================================================================
+      task_config {
+        task_name: "{{ROBOT_NAME}}"          # TODO: must match training task_name
+        robot {
+          usd_filename: "{{USD_FILENAME}}"   # TODO: must match training usd_filename
+          init_pos_z: 0.5
+          # init_joint_pos {                 # TODO: copy from training preset
+          #   key: ".*"
+          #   value: 0.0
+          # }
+        }
+
+        # Copy rewards and observations from your training preset.
+        rewards {
+          key: "progress"
+          value { weight: 1.0 }
+        }
+        rewards {
+          key: "alive"
+          value { weight: 0.5 }
+        }
+        rewards {
+          key: "action_l2"
+          value { weight: -0.005 }
+        }
+        rewards {
+          key: "energy"
+          value { weight: -0.05 }
+        }
+
+        observations {
+          key: "base_height"
+          value {}
+        }
+        observations {
+          key: "base_lin_vel"
+          value {}
+        }
+        observations {
+          key: "base_ang_vel"
+          value {}
+        }
+        observations {
+          key: "joint_pos_norm"
+          value {}
+        }
+        observations {
+          key: "joint_vel_rel"
+          value {
+            params { key: "scale"  value: 0.2 }
+          }
+        }
+        observations {
+          key: "actions"
+          value {}
+        }
+      }
+
+      # Copy network, sim_physics, termination, reset from training preset.
+      network {
+        actor_hidden_dims: 256
+        actor_hidden_dims: 128
+        actor_hidden_dims: 64
+        critic_hidden_dims: 256
+        critic_hidden_dims: 128
+        critic_hidden_dims: 64
+        activation: "elu"
+      }
+      sim_physics {
+        decimation: 2
+        episode_length_s: 16.0
+        sim_dt: 0.00833
+        action_scale: 5.0
+        env_spacing: 5.0
+        terrain_friction: 1.0
+      }
+      termination {
+        min_root_height: 0.2
+      }
+      reset {
+        joint_pos_range_min: -0.2
+        joint_pos_range_max: 0.2
+        joint_vel_range_min: -0.1
+        joint_vel_range_max: 0.1
+      }
+    }
+  }
+}

--- a/config/config_preset/_template_train.pbtxt
+++ b/config/config_preset/_template_train.pbtxt
@@ -1,0 +1,278 @@
+# =============================================================================
+# Training config template for a new robot.
+#
+# Usage:
+#   1. Copy this file to config/config_preset/<robot>/<robot>_train_isaac.pbtxt
+#   2. Replace all TODO markers with your robot's values
+#   3. Uncomment/remove reward and observation terms as needed
+#   4. Run: bazel run //launcher:joshua_main -- \
+#              --config config/config_preset/<robot>/<robot>_train_isaac.pbtxt
+#
+# Or use the scaffold script:
+#   python scripts/new_robot.py --name my_robot --usd my_robot_isaac.usda
+# =============================================================================
+
+general {
+  operation_mode: MODE_TRAINING
+  name: "{{ROBOT_NAME}}"                    # TODO: your robot name
+}
+ai {
+  training {
+    environment: TRAINING_ENV_SIMULATION
+    method: TRAINING_METHOD_RL
+    simulator_backend: SIM_BACKEND_ISAAC_SIM
+    rl {
+      algorithm: "rsl_rl"                    # "rsl_rl" or "skrl"
+      max_iterations: 1000
+      num_envs: 4096
+      save_path: "{{ROBOT_NAME}}_ppo"        # TODO: experiment name for checkpoints
+      render: false
+      seed: 42
+      save_interval: 50
+
+      # =====================================================================
+      # TASK CONFIG -- defines robot, rewards, and observations from proto.
+      # No Python task file needed.
+      # =====================================================================
+      task_config {
+        task_name: "{{ROBOT_NAME}}"          # TODO: drives the gym environment ID
+
+        # -------------------------------------------------------------------
+        # Robot definition
+        #   usd_filename: must exist under simulation/models/
+        #   init_pos_z:   spawn height (meters above ground)
+        #   init_joint_pos: regex patterns matching USD joint names -> radians
+        # -------------------------------------------------------------------
+        robot {
+          usd_filename: "{{USD_FILENAME}}"   # TODO: e.g. "my_robot_isaac.usda"
+          init_pos_z: 0.5                    # TODO: adjust spawn height
+          # init_joint_pos {                 # TODO: set initial joint angles
+          #   key: ".*"                      #   regex matching joint names in USD
+          #   value: 0.0                     #   angle in radians
+          # }
+        }
+
+        # -------------------------------------------------------------------
+        # REWARDS -- pick from the registry below. Use positive weight for
+        # bonuses and negative weight for penalties.
+        #
+        # Available reward terms:
+        #   progress        -- distance toward target (locomotion)
+        #   alive           -- constant bonus while robot is alive
+        #   upright         -- bonus when Z-up projection > threshold
+        #                      params: threshold (default 0.93)
+        #   move_to_target  -- bonus when heading aligns with target
+        #                      params: threshold (default 0.8)
+        #   action_l2       -- penalizes large actions
+        #   energy          -- power consumption penalty
+        #                      gear_ratios: per-joint gear multipliers
+        #   joint_pos_limits -- penalty near joint limits
+        #                      params: threshold; gear_ratios: per-joint
+        #   lin_vel_z       -- penalizes vertical velocity
+        #   ang_vel_xy      -- penalizes roll/pitch angular velocity
+        #   flat_orientation -- penalizes deviation from flat orientation
+        #   action_rate     -- penalizes rapid action changes
+        #   joint_vel       -- penalizes high joint velocities
+        # -------------------------------------------------------------------
+
+        # Locomotion rewards
+        rewards {
+          key: "progress"
+          value { weight: 1.0 }
+        }
+        rewards {
+          key: "alive"
+          value { weight: 0.5 }
+        }
+
+        # Regularization penalties (negative weights)
+        rewards {
+          key: "action_l2"
+          value { weight: -0.005 }
+        }
+        rewards {
+          key: "energy"
+          value { weight: -0.05 }
+        }
+
+        # Uncomment any of these as needed:
+        # rewards {
+        #   key: "upright"
+        #   value {
+        #     weight: 0.1
+        #     params { key: "threshold"  value: 0.93 }
+        #   }
+        # }
+        # rewards {
+        #   key: "move_to_target"
+        #   value {
+        #     weight: 0.5
+        #     params { key: "threshold"  value: 0.8 }
+        #   }
+        # }
+        # rewards {
+        #   key: "joint_pos_limits"
+        #   value { weight: -0.1 }
+        # }
+        # rewards {
+        #   key: "lin_vel_z"
+        #   value { weight: -2.0 }
+        # }
+        # rewards {
+        #   key: "ang_vel_xy"
+        #   value { weight: -0.05 }
+        # }
+        # rewards {
+        #   key: "flat_orientation"
+        #   value { weight: -1.0 }
+        # }
+        # rewards {
+        #   key: "action_rate"
+        #   value { weight: -0.01 }
+        # }
+        # rewards {
+        #   key: "joint_vel"
+        #   value { weight: -0.001 }
+        # }
+
+        # -------------------------------------------------------------------
+        # OBSERVATIONS -- policy inputs. Pick from the registry below.
+        #
+        # Available observation terms:
+        #   base_height       -- root body Z position (1D)
+        #   base_lin_vel      -- root body linear velocity (3D)
+        #   base_ang_vel      -- root body angular velocity (3D)
+        #   base_yaw_roll     -- yaw and roll angles (2D)
+        #   base_angle_to_target -- angle to target position (1D)
+        #   base_up_proj      -- projection of up vector onto Z (1D)
+        #   base_heading_proj -- heading alignment with target (1D)
+        #   joint_pos_norm    -- normalized joint positions (num_joints D)
+        #   joint_vel_rel     -- scaled joint velocities (num_joints D)
+        #                        params: scale (default 0.2)
+        #   body_forces       -- contact forces on named bodies
+        #                        body_names: list of USD body/link names
+        #                        params: scale (default 1.0)
+        #   actions           -- previous action values (num_actions D)
+        # -------------------------------------------------------------------
+
+        observations {
+          key: "base_height"
+          value {}
+        }
+        observations {
+          key: "base_lin_vel"
+          value {}
+        }
+        observations {
+          key: "base_ang_vel"
+          value {}
+        }
+        observations {
+          key: "joint_pos_norm"
+          value {}
+        }
+        observations {
+          key: "joint_vel_rel"
+          value {
+            params { key: "scale"  value: 0.2 }
+          }
+        }
+        observations {
+          key: "actions"
+          value {}
+        }
+
+        # Uncomment for navigation-aware observations:
+        # observations {
+        #   key: "base_yaw_roll"
+        #   value {}
+        # }
+        # observations {
+        #   key: "base_angle_to_target"
+        #   value {}
+        # }
+        # observations {
+        #   key: "base_up_proj"
+        #   value {}
+        # }
+        # observations {
+        #   key: "base_heading_proj"
+        #   value {}
+        # }
+
+        # Uncomment for contact sensing (body_names must match USD links):
+        # observations {
+        #   key: "body_forces"
+        #   value {
+        #     body_names: "foot_1"           # TODO: match your USD body names
+        #     body_names: "foot_2"
+        #     params { key: "scale"  value: 0.1 }
+        #   }
+        # }
+      }
+
+      # =====================================================================
+      # PPO hyperparameters
+      # =====================================================================
+      ppo {
+        learning_rate: 0.0005
+        gamma: 0.99
+        gae_lambda: 0.95
+        clip_epsilon: 0.2
+        entropy_coef: 0.0
+        num_learning_epochs: 5
+        num_minibatches: 4
+        num_steps_per_env: 32
+        desired_kl: 0.01
+        max_grad_norm: 1.0
+        schedule: "adaptive"
+      }
+
+      # =====================================================================
+      # Actor-critic network architecture
+      # =====================================================================
+      network {
+        actor_hidden_dims: 256
+        actor_hidden_dims: 128
+        actor_hidden_dims: 64
+        critic_hidden_dims: 256
+        critic_hidden_dims: 128
+        critic_hidden_dims: 64
+        activation: "elu"
+        init_noise_std: 1.0
+      }
+
+      # =====================================================================
+      # Simulation physics
+      #   decimation:      action repeat (physics steps per env step)
+      #   episode_length_s: max episode duration in seconds
+      #   sim_dt:          physics timestep (seconds)
+      #   action_scale:    multiplier on joint effort actions
+      #   env_spacing:     distance between parallel environments
+      # =====================================================================
+      sim_physics {
+        decimation: 2
+        episode_length_s: 16.0
+        sim_dt: 0.00833
+        action_scale: 5.0                   # TODO: tune for your robot's actuators
+        env_spacing: 5.0
+        terrain_friction: 1.0
+      }
+
+      # =====================================================================
+      # Termination and reset
+      #   min_root_height: episode ends if torso drops below this (meters)
+      #   reset ranges:    joint randomization on episode reset (radians)
+      # =====================================================================
+      termination {
+        min_root_height: 0.2                 # TODO: adjust for your robot's height
+      }
+      reset {
+        joint_pos_range_min: -0.2
+        joint_pos_range_max: 0.2
+        joint_vel_range_min: -0.1
+        joint_vel_range_max: 0.1
+      }
+    }
+  }
+}

--- a/scripts/new_robot.py
+++ b/scripts/new_robot.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Scaffold a new robot for Joshua's Isaac Sim training pipeline.
+
+Generates config presets, directory structure, and a starter README
+from the template files in config/config_preset/.
+
+Usage:
+    python scripts/new_robot.py --name hexapod --usd hexapod_isaac.usda
+    python scripts/new_robot.py --name hexapod  # defaults to <name>_isaac.usda
+"""
+
+import argparse
+import os
+import sys
+
+REPO_ROOT = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..")
+)
+TEMPLATE_DIR = os.path.join(REPO_ROOT, "config", "config_preset")
+PRESET_DIR = os.path.join(REPO_ROOT, "config", "config_preset")
+MODELS_DIR = os.path.join(REPO_ROOT, "simulation", "models")
+
+
+def _read_template(name: str) -> str:
+    path = os.path.join(TEMPLATE_DIR, name)
+    if not os.path.isfile(path):
+        print(f"Error: template not found at {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(path) as f:
+        return f.read()
+
+
+def _substitute(template: str, robot_name: str, usd_filename: str) -> str:
+    return (
+        template
+        .replace("{{ROBOT_NAME}}", robot_name)
+        .replace("{{USD_FILENAME}}", usd_filename)
+    )
+
+
+def _write_file(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+    print(f"  Created: {os.path.relpath(path, REPO_ROOT)}")
+
+
+def _generate_model_readme(robot_name: str, usd_filename: str) -> str:
+    title = robot_name.replace("_", " ").title()
+    return f"""{title}
+{"=" * len(title)}
+
+## Structure
+
+TODO: Describe the robot's body and joint hierarchy.
+
+## USD Asset
+
+- File: `simulation/models/{usd_filename}`
+- Articulation root: `{title}` (or your root prim name)
+- Up axis: Z
+- Units: meters
+
+## Joints
+
+| Joint name | Parent | Child | Type | Range |
+|------------|--------|-------|------|-------|
+| TODO       | TODO   | TODO  | revolute | TODO |
+
+## Config Presets
+
+- Training: `config/config_preset/{robot_name}/{robot_name}_train_isaac.pbtxt`
+- Eval: `config/config_preset/{robot_name}/{robot_name}_eval_isaac.pbtxt`
+
+## Quick Start
+
+```bash
+# Train
+bazel run //launcher:joshua_main -- \\
+    --config config/config_preset/{robot_name}/{robot_name}_train_isaac.pbtxt
+
+# Evaluate (update checkpoint_path in the eval preset first)
+bazel run //launcher:joshua_main -- \\
+    --config config/config_preset/{robot_name}/{robot_name}_eval_isaac.pbtxt
+```
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scaffold a new robot for Joshua training.",
+    )
+    parser.add_argument(
+        "--name", required=True,
+        help="Robot name (snake_case, e.g. hexapod, quadruped)",
+    )
+    parser.add_argument(
+        "--usd", default=None,
+        help="USD filename (default: <name>_isaac.usda). "
+             "Must be placed in simulation/models/.",
+    )
+    parser.add_argument(
+        "--algorithm", default="rsl_rl", choices=["rsl_rl", "skrl"],
+        help="RL algorithm (default: rsl_rl)",
+    )
+    args = parser.parse_args()
+
+    robot_name = args.name.lower().replace("-", "_")
+    usd_filename = args.usd or f"{robot_name}_isaac.usda"
+
+    print(f"\nScaffolding new robot: {robot_name}")
+    print(f"USD filename: {usd_filename}\n")
+
+    config_dir = os.path.join(PRESET_DIR, robot_name)
+    if os.path.exists(config_dir):
+        print(f"Error: {os.path.relpath(config_dir, REPO_ROOT)} already exists.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    train_template = _read_template("_template_train.pbtxt")
+    eval_template = _read_template("_template_eval.pbtxt")
+
+    train_content = _substitute(train_template, robot_name, usd_filename)
+    eval_content = _substitute(eval_template, robot_name, usd_filename)
+
+    if args.algorithm != "rsl_rl":
+        train_content = train_content.replace(
+            'algorithm: "rsl_rl"', f'algorithm: "{args.algorithm}"'
+        )
+        eval_content = eval_content.replace(
+            'algorithm: "rsl_rl"', f'algorithm: "{args.algorithm}"'
+        )
+
+    train_path = os.path.join(config_dir, f"{robot_name}_train_isaac.pbtxt")
+    eval_path = os.path.join(config_dir, f"{robot_name}_eval_isaac.pbtxt")
+    readme_dir = os.path.join(MODELS_DIR, robot_name)
+    readme_path = os.path.join(readme_dir, "README.md")
+
+    print("Generated files:")
+    _write_file(train_path, train_content)
+    _write_file(eval_path, eval_content)
+    _write_file(readme_path, _generate_model_readme(robot_name, usd_filename))
+
+    usd_path = os.path.join(MODELS_DIR, usd_filename)
+
+    print(f"\n{'=' * 60}")
+    print("Next steps:")
+    print(f"{'=' * 60}")
+    print(f"""
+  1. Create your USD articulation:
+     {os.path.relpath(usd_path, REPO_ROOT)}
+
+     Requirements:
+     - Articulation root on the main body (e.g. torso)
+     - Z-up axis, meter units
+     - Collision geometry on all bodies
+     - Joints named descriptively (they appear in config)
+
+  2. Edit the training preset:
+     {os.path.relpath(train_path, REPO_ROOT)}
+
+     Fill in the TODO markers:
+     - init_joint_pos entries matching your USD joint names
+     - Uncomment additional rewards/observations as needed
+     - Tune action_scale for your actuators
+     - Set min_root_height for termination
+
+  3. Run training:
+     bazel run //launcher:joshua_main -- \\
+         --config {os.path.relpath(train_path, REPO_ROOT)}
+
+  4. After training, edit the eval preset:
+     {os.path.relpath(eval_path, REPO_ROOT)}
+
+     - Copy your final task_config from the training preset
+     - Set checkpoint_path to your saved model
+
+  5. Run evaluation:
+     bazel run //launcher:joshua_main -- \\
+         --config {os.path.relpath(eval_path, REPO_ROOT)}
+""")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- _template_train.pbtxt: annotated training config with all 12 reward terms and 11 observation terms documented inline, sensible defaults, and TODO markers for robot-specific values
- _template_eval.pbtxt: matching eval config template
- scripts/new_robot.py: generates config directory, training/eval presets, and model README from templates in one command
- Updated ai/train/README.md and root README.md with scaffold usage

Made-with: Cursor

## Summary

Describe what this PR changes and why.

## Tested

Add screenshot or test results.
