### PR TITLE
Theo/cv camera improvement 2

### DIFF
--- a/robot/perception/camera/cv_camera.cc
+++ b/robot/perception/camera/cv_camera.cc
@@ -11,8 +11,18 @@ CvCamera::CvCamera(const robot::perception::Camera& camera_config) {
   id_ = GetId();
 }
 
+CvCamera::~CvCamera() {
+  std::lock_guard<std::mutex> lock(cap_mutex_);
+  const absl::Status status = TeardownLocked();
+  if (!status.ok()) {
+    LOG(ERROR) << "CvCamera teardown failed in destructor for " << id_ << ": " << status.message();
+  }
+}
+
 absl::Status CvCamera::Init() {
-  absl::Status status = OpenCamera();
+  std::lock_guard<std::mutex> lock(cap_mutex_);
+
+  absl::Status status = OpenCameraLocked();
   if (!status.ok()) {
     return status;
   }
@@ -51,6 +61,11 @@ absl::Status CvCamera::Init() {
 }
 
 absl::Status CvCamera::Teardown() {
+  std::lock_guard<std::mutex> lock(cap_mutex_);
+  return TeardownLocked();
+}
+
+absl::Status CvCamera::TeardownLocked() {
   try {
     if (cap_.isOpened()) {
       cap_.release();
@@ -66,9 +81,10 @@ absl::Status CvCamera::Teardown() {
 }
 
 absl::StatusOr<robot::perception::PerceptionPacket> CvCamera::GetData() {
+  std::lock_guard<std::mutex> lock(cap_mutex_);
+
   try {
-    // Check if camera is still open
-    absl::Status status = OpenCamera();
+    absl::Status status = OpenCameraLocked();
     if (!status.ok()) {
       return status;
     }
@@ -163,7 +179,7 @@ std::string CvCamera::GetId() {
   return id;
 }
 
-absl::Status CvCamera::OpenCamera() {
+absl::Status CvCamera::OpenCameraLocked() {
   absl::Status status;
   
   for (uint8_t i = 0; i < MAX_CAMERA_OPEN_TRIES_; i++) {

--- a/robot/perception/camera/cv_camera.cc
+++ b/robot/perception/camera/cv_camera.cc
@@ -1,10 +1,7 @@
 #include "robot/perception/camera/cv_camera.h"
 
 #include <chrono>
-#include <opencv2/imgcodecs.hpp>
 #include <opencv2/videoio.hpp>
-#include <stdexcept>
-#include <vector>
 
 namespace robot::perception {
 
@@ -119,8 +116,11 @@ absl::StatusOr<robot::perception::PerceptionPacket> CvCamera::GetData() {
     image_data->set_channels(frame.channels());
     image_data->set_encoding("bgr8");  // OpenCV default is BGR
 
-    // Set image data using string assignment to be safe
-    size_t data_size = frame.total() * frame.elemSize();
+    if (!frame.isContinuous()) {
+      frame = frame.clone();
+    }
+
+    const size_t data_size = static_cast<size_t>(frame.total()) * frame.elemSize();
 
     if (data_size == 0) {
       LOG(ERROR) << "Frame data size is 0 for camera " << id_;
@@ -136,9 +136,7 @@ absl::StatusOr<robot::perception::PerceptionPacket> CvCamera::GetData() {
                           "Failed to capture an image from camera with frame data pointer is null");
     }
 
-    // Create a string from the image data and assign it
-    std::string image_string(reinterpret_cast<const char*>(frame.data), data_size);
-    image_data->set_data(image_string);
+    image_data->mutable_data()->assign(reinterpret_cast<const char*>(frame.data), data_size);
 
     VLOG(1) << "Successfully captured frame from camera " << id_ << ": " << frame.cols << "x"
             << frame.rows << " (" << data_size << " bytes)";
@@ -175,8 +173,12 @@ absl::Status CvCamera::OpenCamera() {
     }
     else {
       LOG(ERROR) << "Camera " << id_ << " has not opened. Attempting to reopen...";
-      cap_.open(camera_id_, cv::CAP_V4L2);   
-    } 
+      if (cap_.open(camera_id_, cv::CAP_V4L2)) {
+        if (!cap_.set(cv::CAP_PROP_BUFFERSIZE, 1)) {
+          LOG(ERROR) << "Could not set CAP_PROP_BUFFERSIZE to 1 for camera " << id_;
+        }
+      }
+    }
   }
   if (cap_.isOpened()) {
     status = absl::OkStatus();

--- a/robot/perception/camera/cv_camera.h
+++ b/robot/perception/camera/cv_camera.h
@@ -2,9 +2,8 @@
 
 #include <glog/logging.h>
 
-#include <any>
 #include <cstdint>
-#include <memory>
+#include <mutex>
 #include <opencv2/videoio.hpp>
 #include <string>
 
@@ -19,7 +18,7 @@ namespace robot::perception {
 class CvCamera : public CameraInterface {
  public:
   CvCamera(const robot::perception::Camera& camera_config);
-  ~CvCamera() = default;
+  ~CvCamera() override;
 
   absl::Status Init() override;
   std::string GetId() override;
@@ -29,13 +28,14 @@ class CvCamera : public CameraInterface {
  private:
   const uint8_t MAX_CAMERA_OPEN_TRIES_ = 3;
   cv::VideoCapture cap_;
-  cv::Mat last_frame_;
+  mutable std::mutex cap_mutex_;
   std::string id_;
   uint64_t camera_id_;
   robot::perception::OpenCvConfig opencv_config_;
   mutable robot::perception::PerceptionPacket reusable_packet_;  // Pre-allocated packet for reuse
 
-  absl::Status OpenCamera();
+  absl::Status OpenCameraLocked();
+  absl::Status TeardownLocked();
 };
 
 }  // namespace robot::perception


### PR DESCRIPTION
## Summary
Opencv Camera Class Improvement. 

Performance Improvement: Avoid string copy via direct assign from mutable data, apply single pointer copy safe check, cap buffersize to 1 for fresher frame

Teardown called in CvCamera destructor, cap_mutex_ added to make thread safe for VideoCapture

## Tested

Add screenshot or test results.
