### PR TITLE
fix: update pip install command to ignore installed packages

### DIFF
--- a/dockerfiles/Dockerfile.ubuntu24
+++ b/dockerfiles/Dockerfile.ubuntu24
@@ -124,8 +124,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python Project Dependencies
 # ============================================
 COPY requirements_3.12.lock /tmp/requirements.lock
-RUN python3 -m pip install --upgrade pip --break-system-packages && \
-    python3 -m pip install --no-deps -r /tmp/requirements.lock --break-system-packages && \
+RUN python3 -m pip install --ignore-installed --no-deps -r /tmp/requirements.lock --break-system-packages && \
     rm /tmp/requirements.lock
 
 # Fix for missing NVIDIA libraries in torch
@@ -165,4 +164,3 @@ COPY . /workspace/
 
 # Default command
 CMD ["/bin/bash"]
-


### PR DESCRIPTION
## Summary

The issue happens when user use docker engine instead of docker desktop.

## Tested

Install went smoothly on Ubuntu24.04 with Docker engine.
