### PR TITLE
Add CLAUDE.md and shared Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bazel build:*)",
+      "Bash(bazel test:*)",
+      "Bash(bazel query:*)",
+      "Bash(bazel cquery:*)",
+      "Bash(git status)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(./hooks/lint_check.sh:*)",
+      "Bash(hooks/lint_check.sh:*)",
+      "Bash(buildifier:*)",
+      "Bash(clang-format:*)"
+    ],
+    "deny": [
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Read(.env*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *.c|*.cc|*.cpp|*.h|*.hpp|*.proto) clang-format -i \"$f\" 2>/dev/null || true ;; *.py) black -q \"$f\" 2>/dev/null; isort -q \"$f\" 2>/dev/null ;; BUILD|*/BUILD|*.bazel|*.bzl) buildifier \"$f\" 2>/dev/null || true ;; esac; done; true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+Joshua is a config-driven robotics stack: one protobuf text config (`.pbtxt`) defines
+hardware, AI policy, and operation mode; the launcher builds and runs the matching
+ROS 2 nodes. Bazel monorepo, Ubuntu Linux only (CI: Ubuntu 22.04 / ROS 2 Humble).
+
+## Build & test
+
+```bash
+bazel test //...                          # full suite (same as CI)
+bazel test //<package>:<target>           # targeted, e.g. //ros2/utils:packet_parser_test
+bazel run launcher:joshua_main            # run the full stack
+bazel run //launcher:joshua_main -- --config config/config_preset/so100/teleoperate.pbtxt
+```
+
+Packaged/deployable builds go through `./scripts/build.py` (runs Bazel in Docker) — see `scripts/README.md`.
+
+## Lint & format
+
+```bash
+./hooks/lint_check.sh --fix    # auto-fix files changed since develop (run before committing)
+```
+
+- C/C++/`.proto`: `clang-format` (`.clang-format` at repo root)
+- Python: `black`, `isort`, `flake8`
+- `BUILD` / `BUILD.bazel` / `.bzl`: `buildifier`
+
+## Repo map
+
+- `config/` — protobuf schemas and `.pbtxt` presets (`config/config_preset/<robot>/`); the source of truth for a robot setup
+- `ros2/` — ROS 2 nodes: actions, perceptions, bridges, packet parsing
+- `node_generator/` — turns config into node definitions
+- `launcher/` — `joshua_main` entry point
+- `ai/` — policies and dataset collection (DataStore)
+- `simulation/` — MuJoCo / Isaac Sim models and presets
+- `ui/` — React web control panel
+- `docs/ARCHITECTURE.md` — how config, protos, and ROS 2 connect; read first for cross-cutting changes
+
+Ignore the `bazel-*` symlink directories when searching.
+
+## Conventions
+
+- All PRs target **`develop`** (not main); branches are `<github-username>/<topic>` (e.g. `hmoon/integrate_mujoco`)
+- Commit messages: imperative mood, no strict format
+- Proto / packet changes are high-impact: update the relevant unit tests and coordinate with `node_generator/` and the packet parser
+- Match the naming, structure, and comment density of the surrounding code


### PR DESCRIPTION
## Summary

Sets up project-level Claude Code configuration so every session (for anyone on the team using Claude Code) starts with the repo's context and sane guardrails:

- **`CLAUDE.md`** — loaded into every Claude Code session: Bazel build/test/run commands, `lint_check.sh` usage, a repo map, and PR conventions (target `develop`, `<username>/<topic>` branches). Sourced from README.md and CONTRIBUTING.md.
- **`.claude/settings.json`** — checked-in shared settings:
  - Permission allowlist for common read-only/safe commands (`bazel build/test/query`, `git log/diff/status`, `lint_check.sh`, formatters) so they run without prompting.
  - Denies force-push and reading `.env*` files.
  - A `PostToolUse` hook that auto-formats files Claude edits (`clang-format` for C/C++/proto, `black`/`isort` for Python, `buildifier` for Bazel files), matching the pre-commit tooling.

Personal/machine-specific settings stay in `.claude/settings.local.json` (untouched, not checked in).

## Test plan

- [x] `settings.json` validates as JSON
- [x] Hook command dry-run exits 0 on a sample file
- [x] Pre-push lint hooks passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)