### PR TITLE
Pre-install pinned ros2-apt-source to stabilize CI setup-ros step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Install Bazelisk
         run: sudo npm install -g @bazel/bazelisk
 
+      # setup-ros resolves the ros-apt-source release version through an
+      # unauthenticated GitHub API call that gets rate-limited on shared
+      # runners, producing a malformed download URL and a 404 (issue #63).
+      # Pre-installing a pinned ros2-apt-source package makes setup-ros skip
+      # that download entirely.
+      - name: Install ROS 2 apt source (pinned)
+        run: |
+          curl --fail -sSL --retry 3 --retry-delay 2 -o /tmp/ros2-apt-source.deb \
+            "https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-apt-source_1.2.0.jammy_all.deb"
+          sudo dpkg -i /tmp/ros2-apt-source.deb
+          sudo apt-get update
+
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@v0.7
         with:


### PR DESCRIPTION
## Summary

CI intermittently fails at the `Setup ROS 2` step with `curl: (22)` (#63). The root cause is not renamed release assets: `setup-ros@v0.7` resolves the `ros-apt-source` release version through an **unauthenticated** GitHub API call, which gets rate-limited on shared Actions runners. The version variable then comes back empty, the download URL is malformed (`releases/download//ros2-apt-source_.jammy_all.deb`), and the download 404s. Full analysis in [this comment](https://github.com/Joshua-AI-Robotics/Joshua/issues/63#issuecomment-4899799719).

Updating `setup-ros` doesn't help — the `v0.7` tag already points at the latest release (0.7.19), and the upstream code still makes the call unauthenticated.

## Fix

Add a step before `Setup ROS 2` that installs a pinned `ros2-apt-source_1.2.0.jammy_all.deb` directly (no API lookup). setup-ros checks `apt-cache policy` for `packages.ros.org/ros2/ubuntu` and skips the flaky download entirely when the repo is already configured.

Longer term, moving CI into the repo's Docker image (existing workflow TODO) removes this class of problem.

## Testing

- Verified the pinned asset URL returns HTTP 200.
- Validated the workflow YAML parses.
- CI on this PR exercises the changed workflow directly (`pull_request` targets `develop`).

Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
