### PR TITLE
Board layer: proto groundwork + skeleton (RFC phases 1-2)

### DIFF
--- a/config/config_preset/example/board_layer_example.pbtxt
+++ b/config/config_preset/example/board_layer_example.pbtxt
@@ -13,7 +13,7 @@ general {
 robot {
   boards {
     name: "bridge_1"
-    board_type: ARDUINO_TB6600
+    board_type: ARDUINO_UNO
     comm {
       comm_type: ETHERNET_UDP
       udp_config { host: "192.168.1.50" port: 5555 }
@@ -32,7 +32,7 @@ robot {
   }
   boards {
     name: "arm_bus"
-    board_type: STS3215_BUS
+    board_type: FEETECH_BUS
     comm {
       comm_type: SERIAL
       serial_config { port: "/dev/ttyUSB0" baudrate: 1000000 }

--- a/config/config_preset/example/board_layer_example.pbtxt
+++ b/config/config_preset/example/board_layer_example.pbtxt
@@ -1,0 +1,96 @@
+# Example of the board-layer config shape (docs/BOARD_LAYER_RFC.md §6.4):
+# boards are shared, first-class objects; actuators bind to
+# (board_name, channel) instead of embedding comm. Parse-validated by
+# config_preset_validation_test; the runtime path lands with the board
+# layer rollout phases.
+general {
+  operation_mode: MODE_TEST
+  robot_type: ROBOT_TYPE_MANIPULATOR_ARM
+  name: "board_layer_example"
+  id: 900
+}
+
+robot {
+  boards {
+    name: "bridge_1"
+    board_type: ARDUINO_TB6600
+    comm {
+      comm_type: ETHERNET_UDP
+      udp_config { host: "192.168.1.50" port: 5555 }
+    }
+    channels {
+      index: 0
+      drive: STEP_DIR
+      step_dir { max_pulse_rate_hz: 20000 }
+    }
+    channels {
+      index: 1
+      drive: STEP_DIR
+      step_dir { max_pulse_rate_hz: 20000 }
+    }
+    firmware { name: "tb6600-arduino-eth" min_proto_version: 1 }
+  }
+  boards {
+    name: "arm_bus"
+    board_type: STS3215_BUS
+    comm {
+      comm_type: SERIAL
+      serial_config { port: "/dev/ttyUSB0" baudrate: 1000000 }
+    }
+    channels {
+      index: 0
+      drive: SERVO_BUS_UART
+      servo_bus { servo_id: 1 }
+    }
+  }
+  actions {
+    single_actions {
+      node {
+        id: 1
+        node_type: ACTUATOR_SUBSCRIBER
+        qos_setting { depth: 10 }
+        subscriptions {
+          ros2_data_type: FLOAT32
+          topic: "bridge_joint_1/position"
+          normalized: false
+        }
+      }
+      action_type: ACTUATOR
+      actuator {
+        actuator_name: "bridge_joint_1"
+        id: 1
+        motor_type: MOTOR_STEPPER_NEMA17
+        board_name: "bridge_1"
+        channel: 0
+        physical_lower_limit: -180
+        physical_upper_limit: 180
+        operational_lower_limit: -90
+        operational_upper_limit: 90
+      }
+    }
+    single_actions {
+      node {
+        id: 2
+        node_type: ACTUATOR_SUBSCRIBER
+        qos_setting { depth: 10 }
+        subscriptions {
+          ros2_data_type: FLOAT32
+          topic: "arm_joint_1/position"
+          normalized: false
+        }
+      }
+      action_type: ACTUATOR
+      actuator {
+        actuator_name: "arm_joint_1"
+        id: 2
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 0
+        physical_lower_limit: -180
+        physical_upper_limit: 180
+        operational_lower_limit: -90
+        operational_upper_limit: 90
+      }
+    }
+  }
+}

--- a/config/config_preset/so100/encoder_publish.pbtxt
+++ b/config/config_preset/so100/encoder_publish.pbtxt
@@ -1,3 +1,4 @@
+# TODO(hmoon): Update perception layer with the board too.
 general{
   operation_mode: MODE_TELEOPERATE
   robot_type: ROBOT_TYPE_MANIPULATOR_ARM
@@ -5,6 +6,22 @@ general{
   id: 1
 }
 robot {
+  boards {
+    name: "arm_bus"
+    board_type: FEETECH_BUS
+    comm {
+      comm_type: SERIAL
+      serial_config { port: "/dev/ttyACM0" baudrate: 1000000 }
+    }
+  
+  channels { index: 1 drive: SERVO_BUS_UART servo_bus { servo_id: 1 } }
+  channels { index: 2 drive: SERVO_BUS_UART servo_bus { servo_id: 2 } }
+  channels { index: 3 drive: SERVO_BUS_UART servo_bus { servo_id: 3 } }
+  channels { index: 4 drive: SERVO_BUS_UART servo_bus { servo_id: 4 } }
+  channels { index: 5 drive: SERVO_BUS_UART servo_bus { servo_id: 5 } }
+  channels { index: 6 drive: SERVO_BUS_UART servo_bus { servo_id: 6 } }
+  }
+
   perceptions {
     single_perceptions {
       node {

--- a/config/config_preset/so100/random_noise.pbtxt
+++ b/config/config_preset/so100/random_noise.pbtxt
@@ -5,6 +5,24 @@ general{
   id: 1
 }
 robot {
+  # Board-layer shape (docs/BOARD_LAYER_RFC.md): the servos daisy-chain on
+  # one Feetech bus; actuators bind via (board_name, channel), with channel
+  # index = servo_id. The deprecated actuator_type/comm fields below stay
+  # functional until Phase 4 ports the runtime to the board path.
+  boards {
+    name: "arm_bus"
+    board_type: FEETECH_BUS
+    comm {
+      comm_type: SERIAL
+      serial_config { port: "/dev/ttyACM0" baudrate: 1000000 }
+    }
+    channels { index: 1 drive: SERVO_BUS_UART servo_bus { servo_id: 1 } }
+    channels { index: 2 drive: SERVO_BUS_UART servo_bus { servo_id: 2 } }
+    channels { index: 3 drive: SERVO_BUS_UART servo_bus { servo_id: 3 } }
+    channels { index: 4 drive: SERVO_BUS_UART servo_bus { servo_id: 4 } }
+    channels { index: 5 drive: SERVO_BUS_UART servo_bus { servo_id: 5 } }
+    channels { index: 6 drive: SERVO_BUS_UART servo_bus { servo_id: 6 } }
+  }
   actions {
     single_actions {
       node {
@@ -22,6 +40,9 @@ robot {
         actuator_name: "sts_motor_1"
         id: 1
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 1
         comm {
           comm_type: SERIAL
           serial_config {
@@ -58,6 +79,9 @@ robot {
         actuator_name: "sts_motor_2"
         id: 2
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 2
         comm {
           comm_type: SERIAL
           serial_config {
@@ -94,6 +118,9 @@ robot {
         actuator_name: "sts_motor_3"
         id: 3
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 3
         comm {
           comm_type: SERIAL
           serial_config {
@@ -130,6 +157,9 @@ robot {
         actuator_name: "sts_motor_4"
         id: 4
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 4
         comm {
           comm_type: SERIAL
           serial_config {
@@ -166,6 +196,9 @@ robot {
         actuator_name: "sts_motor_5"
         id: 5
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 5
         comm {
           comm_type: SERIAL
           serial_config {
@@ -202,6 +235,9 @@ robot {
         actuator_name: "sts_motor_6"
         id: 6
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 6
         comm {
           comm_type: SERIAL
           serial_config {

--- a/config/config_preset/so100/random_noise.pbtxt
+++ b/config/config_preset/so100/random_noise.pbtxt
@@ -5,10 +5,6 @@ general{
   id: 1
 }
 robot {
-  # Board-layer shape (docs/BOARD_LAYER_RFC.md): the servos daisy-chain on
-  # one Feetech bus; actuators bind via (board_name, channel), with channel
-  # index = servo_id. The deprecated actuator_type/comm fields below stay
-  # functional until Phase 4 ports the runtime to the board path.
   boards {
     name: "arm_bus"
     board_type: FEETECH_BUS

--- a/config/config_preset/so100/smolvla.pbtxt
+++ b/config/config_preset/so100/smolvla.pbtxt
@@ -5,6 +5,24 @@ general{
   id: 1
 }
 robot {
+  # Board-layer shape (docs/BOARD_LAYER_RFC.md): the servos daisy-chain on
+  # one Feetech bus; actuators bind via (board_name, channel), with channel
+  # index = servo_id. The deprecated actuator_type/comm fields below stay
+  # functional until Phase 4 ports the runtime to the board path.
+  boards {
+    name: "arm_bus"
+    board_type: FEETECH_BUS
+    comm {
+      comm_type: SERIAL
+      serial_config { port: "/dev/ttyACM0" baudrate: 1000000 }
+    }
+    channels { index: 1 drive: SERVO_BUS_UART servo_bus { servo_id: 1 } }
+    channels { index: 2 drive: SERVO_BUS_UART servo_bus { servo_id: 2 } }
+    channels { index: 3 drive: SERVO_BUS_UART servo_bus { servo_id: 3 } }
+    channels { index: 4 drive: SERVO_BUS_UART servo_bus { servo_id: 4 } }
+    channels { index: 5 drive: SERVO_BUS_UART servo_bus { servo_id: 5 } }
+    channels { index: 6 drive: SERVO_BUS_UART servo_bus { servo_id: 6 } }
+  }
   actions {
     single_actions {
       node {
@@ -22,6 +40,9 @@ robot {
         actuator_name: "sts_motor_1"
         id: 1
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 1
         comm {
           comm_type: SERIAL
           serial_config {
@@ -58,6 +79,9 @@ robot {
         actuator_name: "sts_motor_2"
         id: 2
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 2
         comm {
           comm_type: SERIAL
           serial_config {
@@ -94,6 +118,9 @@ robot {
         actuator_name: "sts_motor_3"
         id: 3
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 3
         comm {
           comm_type: SERIAL
           serial_config {
@@ -130,6 +157,9 @@ robot {
         actuator_name: "sts_motor_4"
         id: 4
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 4
         comm {
           comm_type: SERIAL
           serial_config {
@@ -166,6 +196,9 @@ robot {
         actuator_name: "sts_motor_5"
         id: 5
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 5
         comm {
           comm_type: SERIAL
           serial_config {
@@ -202,6 +235,9 @@ robot {
         actuator_name: "sts_motor_6"
         id: 6
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 6
         comm {
           comm_type: SERIAL
           serial_config {

--- a/config/config_preset/so100/smolvla.pbtxt
+++ b/config/config_preset/so100/smolvla.pbtxt
@@ -5,10 +5,6 @@ general{
   id: 1
 }
 robot {
-  # Board-layer shape (docs/BOARD_LAYER_RFC.md): the servos daisy-chain on
-  # one Feetech bus; actuators bind via (board_name, channel), with channel
-  # index = servo_id. The deprecated actuator_type/comm fields below stay
-  # functional until Phase 4 ports the runtime to the board path.
   boards {
     name: "arm_bus"
     board_type: FEETECH_BUS

--- a/config/config_preset/so100/teleoperate.pbtxt
+++ b/config/config_preset/so100/teleoperate.pbtxt
@@ -5,6 +5,24 @@ general{
   id: 1
 }
 robot {
+  # Board-layer shape (docs/BOARD_LAYER_RFC.md): the servos daisy-chain on
+  # one Feetech bus; actuators bind via (board_name, channel), with channel
+  # index = servo_id. The deprecated actuator_type/comm fields below stay
+  # functional until Phase 4 ports the runtime to the board path.
+  boards {
+    name: "arm_bus"
+    board_type: FEETECH_BUS
+    comm {
+      comm_type: SERIAL
+      serial_config { port: "/dev/ttyACM0" baudrate: 1000000 }
+    }
+    channels { index: 1 drive: SERVO_BUS_UART servo_bus { servo_id: 1 } }
+    channels { index: 2 drive: SERVO_BUS_UART servo_bus { servo_id: 2 } }
+    channels { index: 3 drive: SERVO_BUS_UART servo_bus { servo_id: 3 } }
+    channels { index: 4 drive: SERVO_BUS_UART servo_bus { servo_id: 4 } }
+    channels { index: 5 drive: SERVO_BUS_UART servo_bus { servo_id: 5 } }
+    channels { index: 6 drive: SERVO_BUS_UART servo_bus { servo_id: 6 } }
+  }
   actions {
     single_actions {
       node {
@@ -22,6 +40,9 @@ robot {
         actuator_name: "sts3215_servo_1"
         id: 1
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 1
         comm {
           comm_type: SERIAL
           serial_config {
@@ -58,6 +79,9 @@ robot {
         actuator_name: "sts3215_servo_2"
         id: 2
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 2
         comm {
           comm_type: SERIAL
           serial_config {
@@ -94,6 +118,9 @@ robot {
         actuator_name: "sts3215_servo_3"
         id: 3
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 3
         comm {
           comm_type: SERIAL
           serial_config {
@@ -130,6 +157,9 @@ robot {
         actuator_name: "sts3215_servo_4"
         id: 4
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 4
         comm {
           comm_type: SERIAL
           serial_config {
@@ -166,6 +196,9 @@ robot {
         actuator_name: "sts3215_servo_5"
         id: 5
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 5
         comm {
           comm_type: SERIAL
           serial_config {
@@ -202,6 +235,9 @@ robot {
         actuator_name: "sts3215_servo_6"
         id: 6
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 6
         comm {
           comm_type: SERIAL
           serial_config {

--- a/config/config_preset/so100/teleoperate.pbtxt
+++ b/config/config_preset/so100/teleoperate.pbtxt
@@ -5,10 +5,6 @@ general{
   id: 1
 }
 robot {
-  # Board-layer shape (docs/BOARD_LAYER_RFC.md): the servos daisy-chain on
-  # one Feetech bus; actuators bind via (board_name, channel), with channel
-  # index = servo_id. The deprecated actuator_type/comm fields below stay
-  # functional until Phase 4 ports the runtime to the board path.
   boards {
     name: "arm_bus"
     board_type: FEETECH_BUS

--- a/config/config_preset/so100/trajectory_example.pbtxt
+++ b/config/config_preset/so100/trajectory_example.pbtxt
@@ -16,10 +16,6 @@ general {
 }
 
 robot {
-  # Board-layer shape (docs/BOARD_LAYER_RFC.md): the servos daisy-chain on
-  # one Feetech bus; actuators bind via (board_name, channel), with channel
-  # index = servo_id. The deprecated actuator_type/comm fields below stay
-  # functional until Phase 4 ports the runtime to the board path.
   boards {
     name: "arm_bus"
     board_type: FEETECH_BUS

--- a/config/config_preset/so100/trajectory_example.pbtxt
+++ b/config/config_preset/so100/trajectory_example.pbtxt
@@ -16,6 +16,24 @@ general {
 }
 
 robot {
+  # Board-layer shape (docs/BOARD_LAYER_RFC.md): the servos daisy-chain on
+  # one Feetech bus; actuators bind via (board_name, channel), with channel
+  # index = servo_id. The deprecated actuator_type/comm fields below stay
+  # functional until Phase 4 ports the runtime to the board path.
+  boards {
+    name: "arm_bus"
+    board_type: FEETECH_BUS
+    comm {
+      comm_type: SERIAL
+      serial_config { port: "/dev/ttyACM0" baudrate: 1000000 }
+    }
+    channels { index: 1 drive: SERVO_BUS_UART servo_bus { servo_id: 1 } }
+    channels { index: 2 drive: SERVO_BUS_UART servo_bus { servo_id: 2 } }
+    channels { index: 3 drive: SERVO_BUS_UART servo_bus { servo_id: 3 } }
+    channels { index: 4 drive: SERVO_BUS_UART servo_bus { servo_id: 4 } }
+    channels { index: 5 drive: SERVO_BUS_UART servo_bus { servo_id: 5 } }
+    channels { index: 6 drive: SERVO_BUS_UART servo_bus { servo_id: 6 } }
+  }
   actions {
     single_actions {
       node {
@@ -33,6 +51,9 @@ robot {
         actuator_name: "sts_motor_1"
         id: 1
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 1
         comm {
           comm_type: SERIAL
           serial_config {
@@ -69,6 +90,9 @@ robot {
         actuator_name: "sts_motor_2"
         id: 2
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 2
         comm {
           comm_type: SERIAL
           serial_config {
@@ -105,6 +129,9 @@ robot {
         actuator_name: "sts_motor_3"
         id: 3
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 3
         comm {
           comm_type: SERIAL
           serial_config {
@@ -141,6 +168,9 @@ robot {
         actuator_name: "sts_motor_4"
         id: 4
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 4
         comm {
           comm_type: SERIAL
           serial_config {
@@ -177,6 +207,9 @@ robot {
         actuator_name: "sts_motor_5"
         id: 5
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 5
         comm {
           comm_type: SERIAL
           serial_config {
@@ -213,6 +246,9 @@ robot {
         actuator_name: "sts_motor_6"
         id: 6
         actuator_type: STS3215_SERVO
+        motor_type: MOTOR_STS3215
+        board_name: "arm_bus"
+        channel: 6
         comm {
           comm_type: SERIAL
           serial_config {

--- a/config/proto/BUILD
+++ b/config/proto/BUILD
@@ -21,6 +21,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//robot/action/proto:action_proto",
+        "//robot/board/proto:board_proto",
         "//robot/perception/proto:perception_proto",
         "//ros2/proto:trajectory_proto",
     ],

--- a/config/proto/robot.proto
+++ b/config/proto/robot.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "robot/action/proto/action.proto";
+import "robot/board/proto/board.proto";
 import "robot/perception/proto/perception.proto";
 import "ros2/proto/trajectory.proto";
 
@@ -10,4 +11,7 @@ message Robot {
   robot.action.Action actions = 1;
   robot.perception.Perception perceptions = 2;
   ros2.trajectory.Trajectories trajectories = 3;
+  // Shared board controllers; actuators bind to (board_name, channel).
+  // See docs/BOARD_LAYER_RFC.md.
+  repeated robot.board.Board boards = 4;
 }

--- a/config/proto/robot.proto
+++ b/config/proto/robot.proto
@@ -11,7 +11,5 @@ message Robot {
   robot.action.Action actions = 1;
   robot.perception.Perception perceptions = 2;
   ros2.trajectory.Trajectories trajectories = 3;
-  // Shared board controllers; actuators bind to (board_name, channel).
-  // See docs/BOARD_LAYER_RFC.md.
   repeated robot.board.Board boards = 4;
 }

--- a/docs/BOARD_LAYER_RFC.md
+++ b/docs/BOARD_LAYER_RFC.md
@@ -147,7 +147,7 @@ Structural problems this RFC fixes:
       │  "what runs the loop"    │◄─── shared ───┐  │
       │  Am243Board, TeensyBoard,│     codec     │  │
       │  Tb6600ArduinoBoard,     │  joshua_wire  │  │
-      │  Sts3215BusBoard         │     _v1       │  │
+      │  FeetechBusBoard         │     _v1       │  │
       └────────────┬─────────────┘               │  │
                    │ Comm handle                 │  │
                    ▼                             │  │
@@ -213,7 +213,7 @@ robot/
     proto/              board.proto
     am243/              am243_board.*  am243_pdo_codec.*  (moved from motors/drivers)
     tb6600_arduino/     tb6600_arduino_board.*
-    sts3215_bus/        sts3215_bus_board.*  (Feetech register protocol)
+    feetech_bus/        feetech_bus_board.*  (Feetech register protocol)
     host_gpio/          host_gpio_board.*  (Jetson/Pi pins; no comm, no firmware)
   comm/                 serial/  ethercat/  udp/  spi/  factory/  (unchanged role)
 firmware/
@@ -375,7 +375,7 @@ controller the comm leg terminates in.** Each STS3215 contains its own MCU
 speaking the Feetech register protocol; the servo bus is the degenerate case
 where comm and drive are the same physical link:
 
-| Concept | General board | `STS3215_BUS` board |
+| Concept | General board | `FEETECH_BUS` board |
 | --- | --- | --- |
 | `Board.comm` (comm leg) | serial/UDP/EtherCAT to MCU | the serial bus itself |
 | Firmware protocol codec | `joshua_wire_v1` / PDO layout | Feetech register protocol |
@@ -383,7 +383,7 @@ where comm and drive are the same physical link:
 | IDENTIFY handshake | firmware name + proto version | ping servo ID + read model-number register |
 | `FirmwareSpec` / flashing | `tools/flash` artifact | omitted — vendor firmware |
 
-One `Sts3215BusBoard` instance per serial port; each daisy-chained servo is a
+One `FeetechBusBoard` instance per serial port; each daisy-chained servo is a
 channel keyed by `servo_id`. The register-protocol encoding moves out of
 `Sts3215Driver` into this board; the driver shrinks to motor semantics
 (tick↔degree, limits, calibration, idle pose). Bus serialization (one
@@ -393,7 +393,7 @@ board's internal bus mutex.
 The mutex only works if *all* bus traffic goes through the board.
 `Sts3215Encoder` (perception layer) currently writes raw Feetech frames to
 the same shared `Serial` from encoder-publisher timers; after the port it
-reads through `Sts3215BusBoard` (channels already expose `ReadFeedback()`)
+reads through `FeetechBusBoard` (channels already expose `ReadFeedback()`)
 or, at minimum, takes the board's bus lock — otherwise the half-duplex race
 the mutex exists to prevent returns through the perception side door
 (§10 Phase 4). Today's serial cache is also keyed by port *and* baudrate,
@@ -427,7 +427,7 @@ Keeping `board_name` mandatory (rather than optional with an embedded
 `comm{}` fallback) keeps `ActionFactory`, validation, and caching on a single
 code path. The rule generalizes: every motor names a board, and the board
 type says **where the control loop runs** — an external MCU (`AM243`,
-`ARDUINO_TB6600`), the motor's own MCU (`STS3215_BUS`), a vendor hub
+`ARDUINO_UNO`), the motor's own MCU (`FEETECH_BUS`), a vendor hub
 (`SPIKE_HUB_BLE`: the Pybricks hub over BLE), the host itself (`HOST_GPIO`),
 or nowhere (`MOCK`, for tests). "Doesn't need a board" always resolves to
 one of these degenerate cases, never to bypassing the layer. Future smart
@@ -485,12 +485,16 @@ shared bus.
 ### 6.1 `robot/board/proto/board.proto` (new)
 
 ```proto
+// Values name the native controller only — comm peripherals (an EasyCAT
+// shield) belong to Board.comm and drive peripherals (a TB6600 stepper
+// drive) to Channel.drive. Baking a peripheral into the board type would
+// re-conflate the axes this RFC separates.
 enum BoardType {
   BOARD_INVALID = 0;
   AM243 = 1;
-  TEENSY41_ECAT = 2;
-  ARDUINO_TB6600 = 3;
-  STS3215_BUS = 4;        // smart-servo bus; the "board" is the servo's own MCU
+  TEENSY41 = 2;           // comm peripheral (EasyCAT) lives on Board.comm
+  ARDUINO_UNO = 3;        // drive peripheral (TB6600) lives on Channel.drive
+  FEETECH_BUS = 4;        // STS/SCS smart-servo bus; the "board" is the servo's own MCU
   SPIKE_HUB_BLE = 5;      // Pybricks hub; vendor firmware over BLE
   HOST_GPIO = 6;          // no external controller; host pins drive the motor (§5.6)
   MOCK = 7;               // tests; channels are in-memory fakes
@@ -519,7 +523,7 @@ message Channel {
 message FirmwareSpec {
   string name = 1;                  // e.g. "tb6600-arduino-eth"
   uint32 min_proto_version = 2;
-  // Omitted entirely for vendor-firmware boards (STS3215_BUS).
+  // Omitted entirely for vendor-firmware boards (FEETECH_BUS).
 }
 
 message Board {
@@ -580,7 +584,7 @@ kept working but deprecated during migration (§10, Phase 1), then removed.
 robot {
   boards {
     name: "bridge_1"
-    board_type: ARDUINO_TB6600
+    board_type: ARDUINO_UNO
     comm { comm_type: ETHERNET_UDP udp_config { host: "192.168.1.50" port: 5555 } }
     channels { index: 0 drive: STEP_DIR step_dir { max_pulse_rate_hz: 20000 } }
     channels { index: 1 drive: STEP_DIR step_dir { max_pulse_rate_hz: 20000 } }
@@ -588,7 +592,7 @@ robot {
   }
   boards {
     name: "arm_bus"
-    board_type: STS3215_BUS
+    board_type: FEETECH_BUS
     comm { comm_type: SERIAL serial_config { port: "/dev/ttyUSB0" baudrate: 1000000 } }
     channels { index: 0 drive: SERVO_BUS_UART servo_bus { servo_id: 1 } }
     channels { index: 1 drive: SERVO_BUS_UART servo_bus { servo_id: 2 } }
@@ -766,7 +770,7 @@ future Teensy/EasyCAT) is covered by **one** host-side PDO codec — the
 motivation behind open question §12.4. Vendor-controlled protocols are the
 exception and get their own host-side codec each: the TI demo byte-walk
 (`am243_pdo_codec`, kept because we do not control the TI demo firmware) and
-the Feetech register protocol (`Sts3215BusBoard`).
+the Feetech register protocol (`FeetechBusBoard`).
 
 **① is ordinary host-side reuse:** `board.proto` is imported by
 `robot.proto`, compiled once by Bazel, and consumed by every host component
@@ -822,7 +826,7 @@ artifact from a firmware manifest, and invokes the right flasher:
 
 ```
 bazel run //tools/flash -- --config=so100/teleop.pbtxt --board=bridge_1
-  → board_type=ARDUINO_TB6600, comm=ETHERNET_UDP → tb6600-arduino-eth-v1
+  → board_type=ARDUINO_UNO, comm=ETHERNET_UDP → tb6600-arduino-eth-v1
   → avrdude -p m328p -c arduino -U flash:w:tb6600-arduino-eth-v1.hex
 ```
 
@@ -921,11 +925,11 @@ Each phase lands green and independently revertible.
 - [ ] Update `docs/am243_ethercat.md` boundaries section.
 
 ### Phase 4 — Port STS3215
-- [ ] `robot/board/sts3215_bus/Sts3215BusBoard`: Feetech register protocol,
+- [ ] `robot/board/feetech_bus/FeetechBusBoard`: Feetech register protocol,
       per-port instance, bus mutex, servo-ping IDENTIFY.
 - [ ] Slim `Sts3215Driver` to motor semantics over `BoardChannel`
       (byte-identical bus traffic as acceptance bar).
-- [ ] Route `Sts3215Encoder` (perception) through `Sts3215BusBoard` — or at
+- [ ] Route `Sts3215Encoder` (perception) through `FeetechBusBoard` — or at
       minimum through the board's bus lock. It currently writes raw Feetech
       frames to the same shared `Serial` from encoder-publisher timers,
       which would bypass the new bus mutex (§5.6).

--- a/robot/action/proto/action.proto
+++ b/robot/action/proto/action.proto
@@ -10,6 +10,9 @@ enum ActionType {
   ACTUATOR = 1;
 }
 
+// DEPRECATED: board/transport-flavored actuator types are replaced by
+// MotorType + Actuator.board_name (docs/BOARD_LAYER_RFC.md §6.3). Kept
+// functional during the board layer migration; removed in Phase 4 (§10).
 enum ActuatorType {
   ACTUATOR_INVALID = 0;
   STS3215_SERVO = 1;
@@ -18,15 +21,33 @@ enum ActuatorType {
   AM243_ETHERCAT_ACTUATOR = 4;
 }
 
+// What physically moves, independent of the board that runs its loop and
+// the transport that reaches that board. Values carry a MOTOR_ prefix
+// (unlike the RFC sketch) because proto enum values share the package
+// scope with the deprecated ActuatorType during migration.
+enum MotorType {
+  MOTOR_INVALID = 0;
+  MOTOR_STS3215 = 1;
+  MOTOR_STEPPER_NEMA17 = 2;
+  MOTOR_SPIKE = 3;
+  MOTOR_MOCK = 4;
+}
+
 message Actuator {
   string actuator_name = 1;
   uint64 id = 2;
+  // DEPRECATED: use motor_type + board_name + channel instead. Kept
+  // functional during the board layer migration (docs/BOARD_LAYER_RFC.md §10).
   ActuatorType actuator_type = 3;
+  // DEPRECATED: comm now lives on the referenced robot.board.Board.
   robot.comm.Comm comm = 4;
   float physical_lower_limit = 5;  // TODO: Move this to physical layout.
   float physical_upper_limit = 6;  // TODO: Move this to physical layout.
   float operational_lower_limit = 7;
   float operational_upper_limit = 8;
+  MotorType motor_type = 9;
+  string board_name = 10;  // References a config.Robot.boards entry by name.
+  uint32 channel = 15;     // Channel index on that board.
   oneof action_config {
     Sts3215Config sts3215_config = 11;
     MockMotorConfig mock_motor_config = 12;

--- a/robot/board/factory/BUILD
+++ b/robot/board/factory/BUILD
@@ -1,0 +1,52 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_library(
+    name = "board_factory",
+    srcs = ["board_factory.cc"],
+    hdrs = ["board_factory.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//robot/board/interfaces:board_interfaces",
+        "//robot/board/mock:mock_board",
+        "//robot/board/proto:board_cc_proto",
+        "//utils:status_macros",
+        "@abseil-cpp//absl/status:status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "motor_channel_validation",
+    srcs = ["motor_channel_validation.cc"],
+    hdrs = ["motor_channel_validation.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//robot/action/proto:action_cc_proto",
+        "//robot/board/proto:board_cc_proto",
+        "@abseil-cpp//absl/status:status",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "board_factory_test",
+    srcs = ["board_factory_test.cc"],
+    deps = [
+        ":board_factory",
+        "//robot/board/proto:board_cc_proto",
+        "@abseil-cpp//absl/status:status",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "motor_channel_validation_test",
+    srcs = ["motor_channel_validation_test.cc"],
+    deps = [
+        ":motor_channel_validation",
+        "@abseil-cpp//absl/status:status",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/robot/board/factory/board_factory.cc
+++ b/robot/board/factory/board_factory.cc
@@ -26,9 +26,9 @@ absl::StatusOr<std::shared_ptr<BoardInterface>> CreateBoard(const robot::board::
     case robot::board::BoardType::MOCK:
       return std::make_shared<MockBoard>();
     case robot::board::BoardType::AM243:
-    case robot::board::BoardType::STS3215_BUS:
-    case robot::board::BoardType::TEENSY41_ECAT:
-    case robot::board::BoardType::ARDUINO_TB6600:
+    case robot::board::BoardType::FEETECH_BUS:
+    case robot::board::BoardType::TEENSY41:
+    case robot::board::BoardType::ARDUINO_UNO:
     case robot::board::BoardType::SPIKE_HUB_BLE:
     case robot::board::BoardType::HOST_GPIO:
       return absl::UnimplementedError(

--- a/robot/board/factory/board_factory.cc
+++ b/robot/board/factory/board_factory.cc
@@ -1,0 +1,85 @@
+#include "robot/board/factory/board_factory.h"
+
+#include <map>
+#include <mutex>
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "robot/board/mock/mock_board.h"
+#include "utils/status_macros.h"
+
+namespace robot::board {
+
+namespace {
+
+struct CachedBoard {
+  robot::board::BoardType board_type;
+  std::shared_ptr<BoardInterface> board;
+};
+
+static std::mutex g_board_mutex;
+static std::map<std::string, CachedBoard> g_boards;  // keyed by Board.name
+
+absl::StatusOr<std::shared_ptr<BoardInterface>> CreateBoard(const robot::board::Board& config) {
+  switch (config.board_type()) {
+    case robot::board::BoardType::MOCK:
+      return std::make_shared<MockBoard>();
+    case robot::board::BoardType::AM243:
+    case robot::board::BoardType::STS3215_BUS:
+    case robot::board::BoardType::TEENSY41_ECAT:
+    case robot::board::BoardType::ARDUINO_TB6600:
+    case robot::board::BoardType::SPIKE_HUB_BLE:
+    case robot::board::BoardType::HOST_GPIO:
+      return absl::UnimplementedError(
+          absl::StrCat("Board '",
+                       config.name(),
+                       "': board_type ",
+                       robot::board::BoardType_Name(config.board_type()),
+                       " is not implemented yet (docs/BOARD_LAYER_RFC.md §10)."));
+    case robot::board::BoardType::BOARD_INVALID:
+    default:
+      return absl::InvalidArgumentError(
+          absl::StrCat("Board '", config.name(), "' has an invalid board_type."));
+  }
+}
+
+}  // namespace
+
+absl::StatusOr<std::shared_ptr<BoardInterface>> BoardFactory::GetOrCreate(
+    const robot::board::Board& config) {
+  if (config.name().empty()) {
+    return absl::InvalidArgumentError("Board config has no name; boards are cached by name.");
+  }
+
+  std::lock_guard<std::mutex> lock(g_board_mutex);
+  auto it = g_boards.find(config.name());
+  if (it != g_boards.end()) {
+    if (it->second.board_type != config.board_type()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("Board '",
+                       config.name(),
+                       "' is already cached as ",
+                       robot::board::BoardType_Name(it->second.board_type),
+                       " but this config declares ",
+                       robot::board::BoardType_Name(config.board_type()),
+                       "; two boards may not share one name."));
+    }
+    return it->second.board;
+  }
+
+  ABSL_ASSIGN_OR_RETURN(auto board, CreateBoard(config));
+  ABSL_RETURN_IF_ERROR(board->Init(config));
+  g_boards[config.name()] = CachedBoard{config.board_type(), board};
+  return board;
+}
+
+void BoardFactory::ResetForTesting() {
+  std::lock_guard<std::mutex> lock(g_board_mutex);
+  for (auto& [name, cached] : g_boards) {
+    cached.board->Teardown().IgnoreError();
+  }
+  g_boards.clear();
+}
+
+}  // namespace robot::board

--- a/robot/board/factory/board_factory.h
+++ b/robot/board/factory/board_factory.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "robot/board/interfaces/board_interface.h"
+#include "robot/board/proto/board.pb.h"
+
+namespace robot::board {
+
+class BoardFactory {
+ public:
+  // Returns a cached instance per board name — two actuators on the same
+  // board share one instance and one comm handle (docs/BOARD_LAYER_RFC.md
+  // §5.3). The first call for a name creates the board and runs Init();
+  // later calls return the same instance, and fail if their config names a
+  // different board_type than the cached one.
+  static absl::StatusOr<std::shared_ptr<BoardInterface>> GetOrCreate(
+      const robot::board::Board& config);
+
+  // Tears down and forgets every cached board. For tests.
+  static void ResetForTesting();
+
+  ~BoardFactory() = default;
+  BoardFactory(const BoardFactory&) = delete;
+  BoardFactory& operator=(const BoardFactory&) = delete;
+
+ private:
+  BoardFactory() = default;
+};
+
+}  // namespace robot::board

--- a/robot/board/factory/board_factory_test.cc
+++ b/robot/board/factory/board_factory_test.cc
@@ -1,0 +1,121 @@
+#include "robot/board/factory/board_factory.h"
+
+#include "gtest/gtest.h"
+#include "robot/board/proto/board.pb.h"
+
+namespace robot::board {
+namespace {
+
+robot::board::Board MakeMockBoard(const std::string& name, int num_channels) {
+  robot::board::Board board;
+  board.set_name(name);
+  board.set_board_type(robot::board::BoardType::MOCK);
+  for (int i = 0; i < num_channels; ++i) {
+    auto* channel = board.add_channels();
+    channel->set_index(i);
+    channel->set_drive(robot::board::DriveInterface::STEP_DIR);
+  }
+  return board;
+}
+
+class BoardFactoryTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    BoardFactory::ResetForTesting();
+  }
+};
+
+TEST_F(BoardFactoryTest, SameNameSharesOneInstance) {
+  auto board_a = BoardFactory::GetOrCreate(MakeMockBoard("bridge_1", 2));
+  auto board_b = BoardFactory::GetOrCreate(MakeMockBoard("bridge_1", 2));
+  ASSERT_TRUE(board_a.ok()) << board_a.status();
+  ASSERT_TRUE(board_b.ok()) << board_b.status();
+  EXPECT_EQ(board_a->get(), board_b->get());
+}
+
+TEST_F(BoardFactoryTest, DifferentNamesGetDifferentInstances) {
+  auto board_a = BoardFactory::GetOrCreate(MakeMockBoard("bridge_1", 1));
+  auto board_b = BoardFactory::GetOrCreate(MakeMockBoard("bridge_2", 1));
+  ASSERT_TRUE(board_a.ok()) << board_a.status();
+  ASSERT_TRUE(board_b.ok()) << board_b.status();
+  EXPECT_NE(board_a->get(), board_b->get());
+}
+
+TEST_F(BoardFactoryTest, MissingNameIsRejected) {
+  robot::board::Board board = MakeMockBoard("", 1);
+  auto result = BoardFactory::GetOrCreate(board);
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST_F(BoardFactoryTest, InvalidBoardTypeIsRejected) {
+  robot::board::Board board = MakeMockBoard("bad", 1);
+  board.set_board_type(robot::board::BoardType::BOARD_INVALID);
+  auto result = BoardFactory::GetOrCreate(board);
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST_F(BoardFactoryTest, UnportedBoardTypesReportUnimplemented) {
+  robot::board::Board board = MakeMockBoard("am243_1", 1);
+  board.set_board_type(robot::board::BoardType::AM243);
+  auto result = BoardFactory::GetOrCreate(board);
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kUnimplemented);
+}
+
+TEST_F(BoardFactoryTest, SameNameDifferentTypeIsRejected) {
+  auto board_a = BoardFactory::GetOrCreate(MakeMockBoard("bridge_1", 1));
+  ASSERT_TRUE(board_a.ok()) << board_a.status();
+  robot::board::Board conflicting = MakeMockBoard("bridge_1", 1);
+  conflicting.set_board_type(robot::board::BoardType::AM243);
+  auto board_b = BoardFactory::GetOrCreate(conflicting);
+  EXPECT_EQ(board_b.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST_F(BoardFactoryTest, DuplicateChannelIndexIsRejected) {
+  robot::board::Board board = MakeMockBoard("dup", 1);
+  auto* channel = board.add_channels();
+  channel->set_index(0);
+  channel->set_drive(robot::board::DriveInterface::STEP_DIR);
+  auto result = BoardFactory::GetOrCreate(board);
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST_F(BoardFactoryTest, OpenChannelAndRoundTripTarget) {
+  auto board = BoardFactory::GetOrCreate(MakeMockBoard("bridge_1", 2));
+  ASSERT_TRUE(board.ok()) << board.status();
+
+  auto channel = (*board)->OpenChannel(1);
+  ASSERT_TRUE(channel.ok()) << channel.status();
+
+  // Targets are rejected until the channel is enabled.
+  EXPECT_EQ((*channel)->SetTarget(TargetMode::kPosition, 4500.0f).code(),
+            absl::StatusCode::kFailedPrecondition);
+
+  ASSERT_TRUE((*channel)->Enable().ok());
+  ASSERT_TRUE((*channel)->SetTarget(TargetMode::kPosition, 4500.0f).ok());
+  auto feedback = (*channel)->ReadFeedback();
+  ASSERT_TRUE(feedback.ok()) << feedback.status();
+  EXPECT_FLOAT_EQ(feedback->position, 4500.0f);
+
+  // The mock board does not support torque targets (capability, not subclass).
+  EXPECT_EQ((*channel)->SetTarget(TargetMode::kTorque, 1.0f).code(),
+            absl::StatusCode::kUnimplemented);
+}
+
+TEST_F(BoardFactoryTest, OpenChannelOutOfRangeIsNotFound) {
+  auto board = BoardFactory::GetOrCreate(MakeMockBoard("bridge_1", 1));
+  ASSERT_TRUE(board.ok()) << board.status();
+  auto channel = (*board)->OpenChannel(7);
+  EXPECT_EQ(channel.status().code(), absl::StatusCode::kNotFound);
+}
+
+TEST_F(BoardFactoryTest, ResetForTestingDropsCache) {
+  auto board_a = BoardFactory::GetOrCreate(MakeMockBoard("bridge_1", 1));
+  ASSERT_TRUE(board_a.ok()) << board_a.status();
+  BoardFactory::ResetForTesting();
+  auto board_b = BoardFactory::GetOrCreate(MakeMockBoard("bridge_1", 1));
+  ASSERT_TRUE(board_b.ok()) << board_b.status();
+  EXPECT_NE(board_a->get(), board_b->get());
+}
+
+}  // namespace
+}  // namespace robot::board

--- a/robot/board/factory/motor_channel_validation.cc
+++ b/robot/board/factory/motor_channel_validation.cc
@@ -1,0 +1,50 @@
+#include "robot/board/factory/motor_channel_validation.h"
+
+#include "absl/strings/str_cat.h"
+
+namespace robot::board {
+
+namespace {
+
+absl::Status RequireDrive(robot::action::MotorType motor_type,
+                          robot::board::DriveInterface actual,
+                          robot::board::DriveInterface required) {
+  if (actual == required) {
+    return absl::OkStatus();
+  }
+  return absl::InvalidArgumentError(absl::StrCat("Motor ",
+                                                 robot::action::MotorType_Name(motor_type),
+                                                 " requires a ",
+                                                 robot::board::DriveInterface_Name(required),
+                                                 " channel, but the channel's drive is ",
+                                                 robot::board::DriveInterface_Name(actual),
+                                                 "."));
+}
+
+}  // namespace
+
+absl::Status ValidateMotorChannel(robot::action::MotorType motor_type,
+                                  robot::board::DriveInterface drive) {
+  switch (motor_type) {
+    case robot::action::MotorType::MOTOR_STS3215:
+      return RequireDrive(motor_type, drive, robot::board::DriveInterface::SERVO_BUS_UART);
+    case robot::action::MotorType::MOTOR_STEPPER_NEMA17:
+      return RequireDrive(motor_type, drive, robot::board::DriveInterface::STEP_DIR);
+    case robot::action::MotorType::MOTOR_MOCK:
+      // Mock motors accept any real drive; only DRIVE_INVALID is rejected.
+      if (drive == robot::board::DriveInterface::DRIVE_INVALID) {
+        return absl::InvalidArgumentError("Mock motor is bound to a channel with DRIVE_INVALID.");
+      }
+      return absl::OkStatus();
+    case robot::action::MotorType::MOTOR_SPIKE:
+      // Spike motors stay on the Python driver-direct path until the
+      // SPIKE_HUB_BLE board lands (docs/BOARD_LAYER_RFC.md §12.3).
+      return absl::UnimplementedError(
+          "MOTOR_SPIKE has no board channel mapping yet; use the Python Pybricks path.");
+    case robot::action::MotorType::MOTOR_INVALID:
+    default:
+      return absl::InvalidArgumentError("Actuator has an invalid motor_type.");
+  }
+}
+
+}  // namespace robot::board

--- a/robot/board/factory/motor_channel_validation.h
+++ b/robot/board/factory/motor_channel_validation.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "absl/status/status.h"
+#include "robot/action/proto/action.pb.h"
+#include "robot/board/proto/board.pb.h"
+
+namespace robot::board {
+
+// Central motor<->drive compatibility table (docs/BOARD_LAYER_RFC.md §5.5).
+// ActionFactory calls this before constructing a motor driver, so an
+// actuator bound to a channel whose drive cannot move that motor fails at
+// Init() with an actionable error instead of mid-motion.
+absl::Status ValidateMotorChannel(robot::action::MotorType motor_type,
+                                  robot::board::DriveInterface drive);
+
+}  // namespace robot::board

--- a/robot/board/factory/motor_channel_validation_test.cc
+++ b/robot/board/factory/motor_channel_validation_test.cc
@@ -1,0 +1,45 @@
+#include "robot/board/factory/motor_channel_validation.h"
+
+#include "gtest/gtest.h"
+
+namespace robot::board {
+namespace {
+
+using robot::action::MotorType;
+using robot::board::DriveInterface;
+
+TEST(ValidateMotorChannelTest, Sts3215RequiresServoBus) {
+  EXPECT_TRUE(ValidateMotorChannel(MotorType::MOTOR_STS3215, DriveInterface::SERVO_BUS_UART).ok());
+  EXPECT_EQ(ValidateMotorChannel(MotorType::MOTOR_STS3215, DriveInterface::STEP_DIR).code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(ValidateMotorChannel(MotorType::MOTOR_STS3215, DriveInterface::PDO_JOINT).code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
+TEST(ValidateMotorChannelTest, StepperRequiresStepDir) {
+  EXPECT_TRUE(ValidateMotorChannel(MotorType::MOTOR_STEPPER_NEMA17, DriveInterface::STEP_DIR).ok());
+  EXPECT_EQ(
+      ValidateMotorChannel(MotorType::MOTOR_STEPPER_NEMA17, DriveInterface::SERVO_BUS_UART).code(),
+      absl::StatusCode::kInvalidArgument);
+}
+
+TEST(ValidateMotorChannelTest, MockMotorAcceptsAnyRealDrive) {
+  EXPECT_TRUE(ValidateMotorChannel(MotorType::MOTOR_MOCK, DriveInterface::STEP_DIR).ok());
+  EXPECT_TRUE(ValidateMotorChannel(MotorType::MOTOR_MOCK, DriveInterface::PWM_DC).ok());
+  EXPECT_TRUE(ValidateMotorChannel(MotorType::MOTOR_MOCK, DriveInterface::PDO_JOINT).ok());
+  EXPECT_EQ(ValidateMotorChannel(MotorType::MOTOR_MOCK, DriveInterface::DRIVE_INVALID).code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
+TEST(ValidateMotorChannelTest, SpikeIsUnmappedForNow) {
+  EXPECT_EQ(ValidateMotorChannel(MotorType::MOTOR_SPIKE, DriveInterface::PWM_DC).code(),
+            absl::StatusCode::kUnimplemented);
+}
+
+TEST(ValidateMotorChannelTest, InvalidMotorTypeIsRejected) {
+  EXPECT_EQ(ValidateMotorChannel(MotorType::MOTOR_INVALID, DriveInterface::STEP_DIR).code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
+}  // namespace
+}  // namespace robot::board

--- a/robot/board/interfaces/BUILD
+++ b/robot/board/interfaces/BUILD
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "board_interfaces",
+    hdrs = [
+        "board_channel.h",
+        "board_interface.h",
+    ],
+    deps = [
+        "//robot/board/proto:board_cc_proto",
+        "@abseil-cpp//absl/status:status",
+        "@abseil-cpp//absl/status:statusor",
+    ],
+)

--- a/robot/board/interfaces/board_channel.h
+++ b/robot/board/interfaces/board_channel.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace robot::board {
+
+enum class TargetMode { kPosition, kVelocity, kTorque };
+
+struct ChannelFeedback {
+  float position = 0.0f;  // Channel's native unit (steps, ticks).
+  float velocity = 0.0f;
+  uint32_t fault_flags = 0;
+};
+
+// One motor slot on one board. How the command reaches the controller
+// (serial frame, UDP frame, EtherCAT PDO field, servo bus register write)
+// is the board's problem. Values are in the board's native unit; the motor
+// driver owns the degrees<->native conversion (docs/BOARD_LAYER_RFC.md §5.3).
+class BoardChannel {
+ public:
+  virtual ~BoardChannel() = default;
+  virtual absl::Status Enable() = 0;
+  virtual absl::Status Disable() = 0;
+  // A board that cannot do a mode returns UnimplementedError from it.
+  virtual absl::Status SetTarget(TargetMode mode, float value) = 0;
+  virtual absl::StatusOr<ChannelFeedback> ReadFeedback() = 0;
+};
+
+}  // namespace robot::board

--- a/robot/board/interfaces/board_interface.h
+++ b/robot/board/interfaces/board_interface.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "robot/board/interfaces/board_channel.h"
+#include "robot/board/proto/board.pb.h"
+
+namespace robot::board {
+
+// One controller shared by every actuator that names it: two actuators on
+// the same board share one instance and one comm handle
+// (docs/BOARD_LAYER_RFC.md §5.3). Instances come from BoardFactory.
+class BoardInterface {
+ public:
+  virtual ~BoardInterface() = default;
+  // Opens comm, runs the IDENTIFY handshake, pushes CONFIGURE_CHANNEL setup.
+  virtual absl::Status Init(const robot::board::Board& config) = 0;
+  virtual absl::StatusOr<std::shared_ptr<BoardChannel>> OpenChannel(uint32_t index) = 0;
+  virtual absl::Status Teardown() = 0;
+};
+
+}  // namespace robot::board

--- a/robot/board/mock/BUILD
+++ b/robot/board/mock/BUILD
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "mock_board",
+    srcs = ["mock_board.cc"],
+    hdrs = ["mock_board.h"],
+    deps = [
+        "//robot/board/interfaces:board_interfaces",
+        "//robot/board/proto:board_cc_proto",
+        "@abseil-cpp//absl/status:status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+    ],
+)

--- a/robot/board/mock/mock_board.cc
+++ b/robot/board/mock/mock_board.cc
@@ -1,0 +1,105 @@
+#include "robot/board/mock/mock_board.h"
+
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
+namespace robot::board {
+
+namespace {
+
+class MockBoardChannel : public BoardChannel {
+ public:
+  explicit MockBoardChannel(uint32_t index) : index_(index) {}
+
+  absl::Status Enable() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    enabled_ = true;
+    return absl::OkStatus();
+  }
+
+  absl::Status Disable() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    enabled_ = false;
+    return absl::OkStatus();
+  }
+
+  absl::Status SetTarget(TargetMode mode, float value) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!enabled_) {
+      return absl::FailedPreconditionError(
+          absl::StrCat("Mock channel ", index_, " is not enabled."));
+    }
+    switch (mode) {
+      case TargetMode::kPosition:
+        feedback_.position = value;
+        break;
+      case TargetMode::kVelocity:
+        feedback_.velocity = value;
+        break;
+      case TargetMode::kTorque:
+        return absl::UnimplementedError(
+            absl::StrCat("Mock channel ", index_, " does not support torque targets."));
+    }
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<ChannelFeedback> ReadFeedback() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return feedback_;
+  }
+
+ private:
+  const uint32_t index_;
+  std::mutex mutex_;
+  bool enabled_ = false;
+  ChannelFeedback feedback_;
+};
+
+}  // namespace
+
+absl::Status MockBoard::Init(const robot::board::Board& config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (initialized_) {
+    return absl::FailedPreconditionError(
+        absl::StrCat("Mock board '", config.name(), "' is already initialized."));
+  }
+  config_ = config;
+  for (const auto& channel : config.channels()) {
+    if (channels_.count(channel.index()) > 0) {
+      return absl::InvalidArgumentError(absl::StrCat("Board '",
+                                                     config.name(),
+                                                     "' declares channel index ",
+                                                     channel.index(),
+                                                     " more than once."));
+    }
+    channels_[channel.index()] = std::make_shared<MockBoardChannel>(channel.index());
+  }
+  initialized_ = true;
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::shared_ptr<BoardChannel>> MockBoard::OpenChannel(uint32_t index) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!initialized_) {
+    return absl::FailedPreconditionError("Mock board is not initialized.");
+  }
+  auto it = channels_.find(index);
+  if (it == channels_.end()) {
+    return absl::NotFoundError(absl::StrCat("Board '",
+                                            config_.name(),
+                                            "' has no channel ",
+                                            index,
+                                            "; declare it in the board's channels{}."));
+  }
+  return it->second;
+}
+
+absl::Status MockBoard::Teardown() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  channels_.clear();
+  initialized_ = false;
+  return absl::OkStatus();
+}
+
+}  // namespace robot::board

--- a/robot/board/mock/mock_board.h
+++ b/robot/board/mock/mock_board.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <mutex>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "robot/board/interfaces/board_interface.h"
+#include "robot/board/proto/board.pb.h"
+
+namespace robot::board {
+
+// BoardType::MOCK — channels are in-memory fakes. No comm, no firmware;
+// SetTarget stores the value and ReadFeedback echoes it, so motor drivers
+// and the factory seam are testable without hardware.
+class MockBoard : public BoardInterface {
+ public:
+  MockBoard() = default;
+
+  absl::Status Init(const robot::board::Board& config) override;
+  absl::StatusOr<std::shared_ptr<BoardChannel>> OpenChannel(uint32_t index) override;
+  absl::Status Teardown() override;
+
+ private:
+  std::mutex mutex_;
+  bool initialized_ = false;
+  robot::board::Board config_;
+  std::map<uint32_t, std::shared_ptr<BoardChannel>> channels_;
+};
+
+}  // namespace robot::board

--- a/robot/board/proto/BUILD
+++ b/robot/board/proto/BUILD
@@ -1,0 +1,27 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "board_proto",
+    srcs = ["board.proto"],
+    deps = [
+        "//robot/comm/proto:comm_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "board_cc_proto",
+    deps = [
+        ":board_proto",
+    ],
+)
+
+py_proto_library(
+    name = "board_py_proto",
+    deps = [
+        ":board_proto",
+    ],
+)

--- a/robot/board/proto/board.proto
+++ b/robot/board/proto/board.proto
@@ -1,0 +1,103 @@
+syntax = "proto3";
+
+import "robot/comm/proto/comm.proto";
+
+package robot.board;
+
+// The controller that runs the low-level motor loop. The board type says
+// where that loop runs: an external MCU, the motor's own MCU (STS3215_BUS),
+// a vendor hub, the host itself (HOST_GPIO), or nowhere (MOCK).
+// See docs/BOARD_LAYER_RFC.md §5.6 and §6.1.
+enum BoardType {
+  BOARD_INVALID = 0;
+  AM243 = 1;
+  TEENSY41_ECAT = 2;
+  ARDUINO_TB6600 = 3;
+  STS3215_BUS = 4;    // Smart-servo bus; the "board" is the servo's own MCU.
+  SPIKE_HUB_BLE = 5;  // Pybricks hub; vendor firmware over BLE.
+  HOST_GPIO = 6;      // No external controller; host pins drive the motor.
+  MOCK = 7;           // Tests; channels are in-memory fakes.
+}
+
+// The drive leg: how the board moves the motor (docs/BOARD_LAYER_RFC.md §5.5).
+enum DriveInterface {
+  DRIVE_INVALID = 0;
+  STEP_DIR = 1;  // Pulse/direction stepper drive (TB6600, ...).
+  PWM_DC = 2;
+  SERVO_BUS_UART = 3;  // Feetech/Dynamixel-style register bus.
+  CAN = 4;
+  PDO_JOINT = 5;  // Slot in a cyclic EtherCAT process-data image.
+}
+
+message StepDirConfig {
+  uint32 max_pulse_rate_hz = 1;
+  bool invert_dir = 2;
+  bool enable_active_low = 3;
+}
+
+message ServoBusConfig {
+  uint32 servo_id = 1;
+}
+
+message PwmConfig {
+  uint32 frequency_hz = 1;
+  float deadband = 2;
+}
+
+message HostGpioConfig {
+  string gpio_chip = 1;      // e.g. "/dev/gpiochip0"
+  repeated uint32 pins = 2;  // Pin group on the host header.
+}
+
+// One motor slot on one board. Wiring facts are baked into the firmware
+// variant; the tunables below are pushed at Init() via CONFIGURE_CHANNEL.
+message Channel {
+  uint32 index = 1;
+  DriveInterface drive = 2;
+  oneof drive_config {
+    StepDirConfig step_dir = 10;
+    ServoBusConfig servo_bus = 11;
+    PwmConfig pwm = 12;
+    HostGpioConfig host_gpio = 13;  // HOST_GPIO boards only.
+  }
+}
+
+// Which firmware the host expects on the board; verified against the
+// IDENTIFY handshake at Init(). Omitted entirely for vendor-firmware
+// boards (STS3215_BUS, SPIKE_HUB_BLE) and for HOST_GPIO / MOCK.
+message FirmwareSpec {
+  string name = 1;  // e.g. "tb6600-arduino-eth"
+  uint32 min_proto_version = 2;
+}
+
+// Future home of the AM243 PDO mapping selector; mirrors
+// robot.action.Am243PdoMapping until the deprecated actuator-embedded
+// config is removed in Phase 4 (docs/BOARD_LAYER_RFC.md §10).
+enum Am243PdoMapping {
+  AM243_PDO_MAPPING_UNSPECIFIED = 0;
+  AM243_PDO_MAPPING_TI_DEMO = 1;
+  AM243_PDO_MAPPING_ACTUATOR_V1 = 2;
+}
+
+message Am243Config {
+  uint32 slave_index = 1;
+  Am243PdoMapping pdo_mapping = 2;
+  // PDO region override (offsets/sizes) so presets can pin regions instead
+  // of trusting GetPdoRegion auto-discovery.
+  uint32 output_offset_bytes = 3;
+  uint32 input_offset_bytes = 4;
+  uint32 output_size_bytes = 5;
+  uint32 input_size_bytes = 6;
+}
+
+message Board {
+  string name = 1;  // Referenced by actuators; cache key.
+  BoardType board_type = 2;
+  robot.comm.Comm comm = 3;       // Comm leg: how the PC reaches the controller
+                                  // (omitted for HOST_GPIO / MOCK).
+  repeated Channel channels = 4;  // Drive leg: what each slot drives.
+  FirmwareSpec firmware = 5;
+  oneof board_config {
+    Am243Config am243_config = 10;
+  }
+}

--- a/robot/board/proto/board.proto
+++ b/robot/board/proto/board.proto
@@ -5,15 +5,19 @@ import "robot/comm/proto/comm.proto";
 package robot.board;
 
 // The controller that runs the low-level motor loop. The board type says
-// where that loop runs: an external MCU, the motor's own MCU (STS3215_BUS),
+// where that loop runs: an external MCU, the motor's own MCU (FEETECH_BUS),
 // a vendor hub, the host itself (HOST_GPIO), or nowhere (MOCK).
+// Values name the native controller only — comm peripherals (e.g. an
+// EasyCAT shield) belong to Board.comm and drive peripherals (e.g. a
+// TB6600 stepper drive) to Channel.drive, never to the board type.
 // See docs/BOARD_LAYER_RFC.md §5.6 and §6.1.
 enum BoardType {
   BOARD_INVALID = 0;
   AM243 = 1;
-  TEENSY41_ECAT = 2;
-  ARDUINO_TB6600 = 3;
-  STS3215_BUS = 4;    // Smart-servo bus; the "board" is the servo's own MCU.
+  TEENSY41 = 2;
+  ARDUINO_UNO = 3;
+  FEETECH_BUS = 4;    // STS/SCS smart-servo register bus; the "board" is the
+                      // servo's own MCU.
   SPIKE_HUB_BLE = 5;  // Pybricks hub; vendor firmware over BLE.
   HOST_GPIO = 6;      // No external controller; host pins drive the motor.
   MOCK = 7;           // Tests; channels are in-memory fakes.
@@ -64,7 +68,7 @@ message Channel {
 
 // Which firmware the host expects on the board; verified against the
 // IDENTIFY handshake at Init(). Omitted entirely for vendor-firmware
-// boards (STS3215_BUS, SPIKE_HUB_BLE) and for HOST_GPIO / MOCK.
+// boards (FEETECH_BUS, SPIKE_HUB_BLE) and for HOST_GPIO / MOCK.
 message FirmwareSpec {
   string name = 1;  // e.g. "tb6600-arduino-eth"
   uint32 min_proto_version = 2;

--- a/robot/comm/proto/comm.proto
+++ b/robot/comm/proto/comm.proto
@@ -8,6 +8,7 @@ enum CommType {
   SERIAL = 1;
   BLE = 2;
   ETHERCAT = 3;
+  ETHERNET_UDP = 4;
 }
 
 message Comm {
@@ -15,6 +16,7 @@ message Comm {
   oneof comm_config {
     SerialConfig serial_config = 2;
     EthercatConfig ethercat_config = 3;
+    UdpConfig udp_config = 4;
   }
 }
 
@@ -22,6 +24,11 @@ message SerialConfig {
   uint64 id = 1;
   string port = 2;
   uint64 baudrate = 3;
+}
+
+message UdpConfig {
+  string host = 1;
+  uint32 port = 2;
 }
 
 enum EthercatProcessDataMode {


### PR DESCRIPTION
Implements Phases 1 and 2 of [docs/BOARD_LAYER_RFC.md](docs/BOARD_LAYER_RFC.md) — the proto groundwork and the host-side board layer skeleton. No hardware paths change; existing `ActuatorType` configs keep working untouched.

## Phase 1 — Proto groundwork
- **New `robot/board/proto/board.proto`**: `BoardType`, `DriveInterface`, `Channel` (with `drive_config` oneof: step_dir / servo_bus / pwm / host_gpio), `FirmwareSpec`, `Board` (with `am243_config` oneof carrying the PDO region override).
- **`config.Robot`** gains `repeated robot.board.Board boards = 4`.
- **`Actuator`** gains `motor_type`, `board_name`, `channel`; `actuator_type` and the embedded `comm` are comment-deprecated (still fully functional) until Phase 4 removes them.
- **`comm.proto`** gains `ETHERNET_UDP` + `UdpConfig` (SPI deferred per RFC).
- New-shape example preset (`config/config_preset/example/board_layer_example.pbtxt`, the RFC §6.4 example) is parse-validated by the existing `config_preset_validation_test` alongside all old-shape presets.

## Phase 2 — Board layer skeleton
- **`robot/board/interfaces/`**: `BoardChannel` (Enable/Disable/SetTarget/ReadFeedback, `TargetMode`, `ChannelFeedback`) and `BoardInterface` (Init/OpenChannel/Teardown) — the seam from RFC §5.3.
- **`robot/board/factory/BoardFactory`**: instance cache keyed by board name — two actuators naming the same board share one instance; a second config reusing a name with a different `board_type` is rejected. Unported board types return `UnimplementedError` naming the RFC phase.
- **`ValidateMotorChannel(motor_type, drive)`**: the central motor↔drive compatibility table from RFC §5.5 (STS3215→SERVO_BUS_UART, stepper→STEP_DIR, mock→any, spike→unimplemented until §12.3 is settled).
- **`robot/board/mock/MockBoard`** (`BoardType::MOCK`): in-memory channels so the factory and seam are testable without hardware; rejects targets on disabled channels and torque targets (capability, not subclass).

## Deviations from the RFC sketch (each mirrored into the RFC doc)
- **`MotorType` values are prefixed** (`MOTOR_STS3215`, `MOTOR_STEPPER_NEMA17`, …) because proto enum values share the package scope with the still-present `ActuatorType` (`SPIKE_MOTOR`/`MOCK_MOTOR` would collide during the migration window).
- **`BoardType` uses native controller names**: `TEENSY41` (was `TEENSY41_ECAT`) and `ARDUINO_UNO` (was `ARDUINO_TB6600`). The old names double-encoded the legs — EasyCAT is the comm leg (`Board.comm`), TB6600 is the drive leg (`Channel.drive`) — re-conflating the axes the RFC separates. Invalid (board, comm) combos are still rejected, by the flash manifest and the IDENTIFY handshake rather than by the enum.
- **`STS3215_BUS` → `FEETECH_BUS`**: the "board" is whatever speaks Feetech registers on the UART, which covers STS/SCS siblings; the RFC's sketched `Sts3215BusBoard` follows as `FeetechBusBoard`, while `Sts3215Driver` stays motor-specific.

## Deferred (with rationale)
- Moving the serial `PortResources` cache out of `comm_factory.cc` (last Phase 2 bullet): it has no board-layer consumer until `FeetechBusBoard` lands in Phase 4, so moving it now would be dead plumbing. Flagged in the commit message.

## Testing
- `bazel test //robot/board/... //config/... //robot/comm/... //robot/action/...` — 11/11 targets pass, including the new `board_factory_test` (shared-instance, name-conflict, channel round-trip, fail-fast cases) and `motor_channel_validation_test`.
- `hooks/lint_check.sh` clean (clang-format applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
