### PR TITLE
setup.sh: remove conflicting Ubuntu Docker packages before install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Version numbers are defined in [`VERSION`](VERSION). Git tags use the form `vX.Y
   `so100/sim_interactive.pbtxt` / `sim_mirror.pbtxt` filenames
 - Docker docs now include the required Compose `--profile` flags for ARM64, Jazzy,
   and the web UI (`production` profile) services
+- `scripts/setup.sh` now removes conflicting Ubuntu-archive Docker packages
+  (`docker.io`, `docker-compose`, `docker-compose-v2`, etc.) before installing
+  the docker.com packages, so hosts with stock Ubuntu Docker already installed
+  no longer hit a `dpkg` "trying to overwrite" error on `docker-compose-plugin`
 
 ### Removed
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -49,6 +49,15 @@ fi
 echo -e "${GREEN}=== Joshua Docker host bootstrap ===${NC}"
 echo -e "${BLUE}Installing Docker Engine, Compose v2, and buildx if needed...${NC}"
 
+# Ubuntu's archive ships its own Docker/Compose packages (docker.io,
+# docker-compose, docker-compose-v2, ...) that conflict with the docker.com
+# packages installed below -- e.g. docker-compose-plugin and docker-compose-v2
+# both ship /usr/libexec/docker/cli-plugins/docker-compose, so dpkg refuses to
+# unpack docker-compose-plugin while the Ubuntu package is present. Remove the
+# conflicting Ubuntu-archive packages first (no-op if they aren't installed).
+CONFLICTING_PACKAGES=(docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc)
+apt-get remove -y "${CONFLICTING_PACKAGES[@]}" || true
+
 DOCKER_SOURCES=/etc/apt/sources.list.d/docker.sources
 LEGACY_DOCKER_LIST=/etc/apt/sources.list.d/docker.list
 DOCKER_REPOSITORY=https://download.docker.com/linux/ubuntu


### PR DESCRIPTION
## Summary
- `scripts/setup.sh` installs `docker-ce`/`docker-compose-plugin` from Docker's official apt repo, but hosts that already have Ubuntu's own Docker packages (`docker.io`, `docker-compose`, `docker-compose-v2`, ...) hit a dpkg "trying to overwrite" error, since both package sets ship `/usr/libexec/docker/cli-plugins/docker-compose`. This is the exact error hit on this host while testing PR #57.
- Removes the conflicting Ubuntu-archive packages (best-effort `apt-get remove`, no-op if absent) before installing the docker.com packages, matching Docker's own documented cleanup step for this scenario.
- Adds a CHANGELOG entry.

## Test plan
- [x] `bash -n scripts/setup.sh` (syntax only)
- [ ] Full `sudo ./scripts/setup.sh` run not exercised end-to-end here (would require destructive package changes on this host); the added block is a straightforward `apt-get remove -y <list> || true` matching Docker's documented pre-install cleanup, run before the existing `apt-get install` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)